### PR TITLE
Feature/rcp 0007 cart screen

### DIFF
--- a/Recipe/Recipe.xcodeproj/project.pbxproj
+++ b/Recipe/Recipe.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		CEA024F82C6611E200CA0CF7 /* ValidationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA024F72C6611E200CA0CF7 /* ValidationService.swift */; };
 		CEAD430C2C6500610058B337 /* LoginSelectVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEAD430A2C6500610058B337 /* LoginSelectVC.swift */; };
 		CEAD430D2C6500610058B337 /* LoginSelectVC.xib in Resources */ = {isa = PBXBuildFile; fileRef = CEAD430B2C6500610058B337 /* LoginSelectVC.xib */; };
+		CEB44CB82C9C262C00545B41 /* CartVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB44CB72C9C262C00545B41 /* CartVM.swift */; };
 		CEBB3F202C675CD100042C52 /* AuthRemoteDatasource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEBB3F1F2C675CD100042C52 /* AuthRemoteDatasource.swift */; };
 		CEBB3F222C6768A600042C52 /* RecipeRequestInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEBB3F212C6768A600042C52 /* RecipeRequestInterceptor.swift */; };
 		CEBB3F242C676C7000042C52 /* RegisterRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEBB3F232C676C7000042C52 /* RegisterRequest.swift */; };
@@ -145,6 +146,7 @@
 		CEA024F72C6611E200CA0CF7 /* ValidationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationService.swift; sourceTree = "<group>"; };
 		CEAD430A2C6500610058B337 /* LoginSelectVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginSelectVC.swift; sourceTree = "<group>"; };
 		CEAD430B2C6500610058B337 /* LoginSelectVC.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LoginSelectVC.xib; sourceTree = "<group>"; };
+		CEB44CB72C9C262C00545B41 /* CartVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartVM.swift; sourceTree = "<group>"; };
 		CEBB3F1F2C675CD100042C52 /* AuthRemoteDatasource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthRemoteDatasource.swift; sourceTree = "<group>"; };
 		CEBB3F212C6768A600042C52 /* RecipeRequestInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeRequestInterceptor.swift; sourceTree = "<group>"; };
 		CEBB3F232C676C7000042C52 /* RegisterRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterRequest.swift; sourceTree = "<group>"; };
@@ -386,6 +388,7 @@
 			children = (
 				CE91AE592C8EF57700D3FB58 /* Cell */,
 				CE91AE4B2C8EF3F900D3FB58 /* CartVC.swift */,
+				CEB44CB72C9C262C00545B41 /* CartVM.swift */,
 			);
 			path = Cart;
 			sourceTree = "<group>";
@@ -775,6 +778,7 @@
 				CE91AE652C8EF59700D3FB58 /* RecipeCardViewCell.swift in Sources */,
 				B94BAE9A2C634EB200B043B7 /* OnBoardingCell.swift in Sources */,
 				FE2636C02C5FF32E00B907CC /* BaseViewController.swift in Sources */,
+				CEB44CB82C9C262C00545B41 /* CartVM.swift in Sources */,
 				7880082F2C627F2F00AA1EEA /* UIColor.swift in Sources */,
 				7880082D2C627EF500AA1EEA /* Colors.swift in Sources */,
 				788008312C62867F00AA1EEA /* UIButton.swift in Sources */,

--- a/Recipe/Recipe.xcodeproj/project.pbxproj
+++ b/Recipe/Recipe.xcodeproj/project.pbxproj
@@ -38,6 +38,8 @@
 		B94BAEA92C63FDEF00B043B7 /* SplashVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = B94BAEA62C63FDEF00B043B7 /* SplashVC.swift */; };
 		B94BAEAC2C64001F00B043B7 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = B94BAEAB2C64001F00B043B7 /* Lottie */; };
 		B94BAEAE2C64015300B043B7 /* splashAnimation.json in Resources */ = {isa = PBXBuildFile; fileRef = B94BAEAD2C64015300B043B7 /* splashAnimation.json */; };
+		CE29006F2CA6B0D200AF20DE /* RealmRecipeDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE29006E2CA6B0D200AF20DE /* RealmRecipeDataSource.swift */; };
+		CE2900712CA6B39600AF20DE /* RecipeRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2900702CA6B39600AF20DE /* RecipeRepository.swift */; };
 		CE3D90422CA018080054F3E0 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = CE3D90412CA018080054F3E0 /* RealmSwift */; };
 		CE4E86B82C667A9C0082E5AD /* AlamofireRecipeEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4E86B72C667A9C0082E5AD /* AlamofireRecipeEndpoint.swift */; };
 		CE4F9EA42C8F4C410060EA44 /* DropDown in Frameworks */ = {isa = PBXBuildFile; productRef = CE4F9EA32C8F4C410060EA44 /* DropDown */; };
@@ -140,6 +142,8 @@
 		B94BAEA02C63ECBE00B043B7 /* color.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = color.xcassets; sourceTree = "<group>"; };
 		B94BAEA62C63FDEF00B043B7 /* SplashVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashVC.swift; sourceTree = "<group>"; };
 		B94BAEAD2C64015300B043B7 /* splashAnimation.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = splashAnimation.json; sourceTree = "<group>"; };
+		CE29006E2CA6B0D200AF20DE /* RealmRecipeDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmRecipeDataSource.swift; sourceTree = "<group>"; };
+		CE2900702CA6B39600AF20DE /* RecipeRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeRepository.swift; sourceTree = "<group>"; };
 		CE4E86B72C667A9C0082E5AD /* AlamofireRecipeEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlamofireRecipeEndpoint.swift; sourceTree = "<group>"; };
 		CE6364702C67507B00944D1F /* LoginRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginRequest.swift; sourceTree = "<group>"; };
 		CE6364722C67521C00944D1F /* LoginResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginResponse.swift; sourceTree = "<group>"; };
@@ -243,7 +247,6 @@
 			isa = PBXGroup;
 			children = (
 				786896D02C63D8E60038B60C /* DummyData.swift */,
-				CE91AE672C8F008600D3FB58 /* Recipe.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -397,6 +400,7 @@
 			isa = PBXGroup;
 			children = (
 				CE8FACA62C68CDEE00A1527A /* KeychainManager.swift */,
+				CE29006E2CA6B0D200AF20DE /* RealmRecipeDataSource.swift */,
 			);
 			path = local;
 			sourceTree = "<group>";
@@ -416,10 +420,10 @@
 			children = (
 				CE91AE5B2C8EF59600D3FB58 /* CategoryTableViewCell.swift */,
 				CE91AE5A2C8EF59600D3FB58 /* CategoryTableViewCell.xib */,
-				CE91AE5E2C8EF59700D3FB58 /* RecipeCardCell.swift */,
-				CE91AE5D2C8EF59600D3FB58 /* RecipeCardCell.xib */,
 				CE91AE5F2C8EF59700D3FB58 /* RecipeCardViewCell.swift */,
 				CE91AE5C2C8EF59600D3FB58 /* RecipeCardViewCell.xib */,
+				CE91AE5E2C8EF59700D3FB58 /* RecipeCardCell.swift */,
+				CE91AE5D2C8EF59600D3FB58 /* RecipeCardCell.xib */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -459,6 +463,7 @@
 			isa = PBXGroup;
 			children = (
 				CEC6BC462C677A2E0033A30E /* AuthRepository.swift */,
+				CE2900702CA6B39600AF20DE /* RecipeRepository.swift */,
 			);
 			path = Repositories;
 			sourceTree = "<group>";
@@ -466,6 +471,7 @@
 		CEA024F42C66111800CA0CF7 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				CE91AE672C8F008600D3FB58 /* Recipe.swift */,
 				CEC6BC452C6778370033A30E /* Responses */,
 				CE63646F2C67506300944D1F /* Requests */,
 			);
@@ -773,8 +779,10 @@
 				7880082B2C627E6400AA1EEA /* Fonts.swift in Sources */,
 				E1C5A6DB2C6766380035ABC8 /* SignupOptionsVC.swift in Sources */,
 				786896C22C637D590038B60C /* PersonalizeRecipesCell.swift in Sources */,
+				CE2900712CA6B39600AF20DE /* RecipeRepository.swift in Sources */,
 				786896CE2C63CEE20038B60C /* FlexibleGridViewComponents.swift in Sources */,
 				FE2636BC2C5FF32E00B907CC /* AppDelegate.swift in Sources */,
+				CE29006F2CA6B0D200AF20DE /* RealmRecipeDataSource.swift in Sources */,
 				E1A276862C6691C10056D225 /* Regex.swift in Sources */,
 				E1A2767F2C665CC10056D225 /* SignupVC.swift in Sources */,
 				CEC6BC472C677A2E0033A30E /* AuthRepository.swift in Sources */,

--- a/Recipe/Recipe.xcodeproj/project.pbxproj
+++ b/Recipe/Recipe.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		B94BAEA92C63FDEF00B043B7 /* SplashVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = B94BAEA62C63FDEF00B043B7 /* SplashVC.swift */; };
 		B94BAEAC2C64001F00B043B7 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = B94BAEAB2C64001F00B043B7 /* Lottie */; };
 		B94BAEAE2C64015300B043B7 /* splashAnimation.json in Resources */ = {isa = PBXBuildFile; fileRef = B94BAEAD2C64015300B043B7 /* splashAnimation.json */; };
+		CE3D90422CA018080054F3E0 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = CE3D90412CA018080054F3E0 /* RealmSwift */; };
 		CE4E86B82C667A9C0082E5AD /* AlamofireRecipeEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4E86B72C667A9C0082E5AD /* AlamofireRecipeEndpoint.swift */; };
 		CE4F9EA42C8F4C410060EA44 /* DropDown in Frameworks */ = {isa = PBXBuildFile; productRef = CE4F9EA32C8F4C410060EA44 /* DropDown */; };
 		CE6364712C67507B00944D1F /* LoginRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6364702C67507B00944D1F /* LoginRequest.swift */; };
@@ -69,6 +70,7 @@
 		CEC6BC472C677A2E0033A30E /* AuthRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC6BC462C677A2E0033A30E /* AuthRepository.swift */; };
 		CEC6BC492C677C160033A30E /* LoginVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC6BC482C677C160033A30E /* LoginVM.swift */; };
 		CEF628AA2C66711E00DA0C7B /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF628A92C66711E00DA0C7B /* NetworkError.swift */; };
+		CEFEBC4E2C9D4330001D9A28 /* RecipeEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFEBC4D2C9D4330001D9A28 /* RecipeEntity.swift */; };
 		E1A276772C665A600056D225 /* FloatingLabelInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A276762C665A600056D225 /* FloatingLabelInput.swift */; };
 		E1A2767F2C665CC10056D225 /* SignupVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A2767D2C665CC10056D225 /* SignupVC.swift */; };
 		E1A276802C665CC10056D225 /* SignupVC.xib in Resources */ = {isa = PBXBuildFile; fileRef = E1A2767E2C665CC10056D225 /* SignupVC.xib */; };
@@ -93,6 +95,19 @@
 		FE2636E22C5FF76800B907CC /* Poppins-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = FE2636DE2C5FF76800B907CC /* Poppins-Bold.ttf */; };
 		FE2636E32C5FF76800B907CC /* Poppins-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = FE2636DF2C5FF76800B907CC /* Poppins-Regular.ttf */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		CE5E1E3B2C9FC86A00FAF1D9 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		78607D152C6124EC008AA26B /* PersonalizeOptionVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonalizeOptionVC.swift; sourceTree = "<group>"; };
@@ -153,6 +168,7 @@
 		CEC6BC462C677A2E0033A30E /* AuthRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthRepository.swift; sourceTree = "<group>"; };
 		CEC6BC482C677C160033A30E /* LoginVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginVM.swift; sourceTree = "<group>"; };
 		CEF628A92C66711E00DA0C7B /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
+		CEFEBC4D2C9D4330001D9A28 /* RecipeEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeEntity.swift; sourceTree = "<group>"; };
 		E1A276762C665A600056D225 /* FloatingLabelInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingLabelInput.swift; sourceTree = "<group>"; };
 		E1A2767D2C665CC10056D225 /* SignupVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupVC.swift; sourceTree = "<group>"; };
 		E1A2767E2C665CC10056D225 /* SignupVC.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SignupVC.xib; sourceTree = "<group>"; };
@@ -185,6 +201,7 @@
 				FE2636DA2C5FF58C00B907CC /* IQKeyboardManagerSwift in Frameworks */,
 				E1E1FDFA2C6782F700862CFC /* GoogleSignIn in Frameworks */,
 				E1E1FDF52C6782C900862CFC /* FacebookCore in Frameworks */,
+				CE3D90422CA018080054F3E0 /* RealmSwift in Frameworks */,
 				E1E1FDF72C6782C900862CFC /* FacebookLogin in Frameworks */,
 				CE8A6D5B2C661CA600DE54C5 /* Alamofire in Frameworks */,
 				CE4F9EA42C8F4C410060EA44 /* DropDown in Frameworks */,
@@ -327,6 +344,7 @@
 			isa = PBXGroup;
 			children = (
 				B94BAE9E2C63DD8400B043B7 /* OnBoardingEntity.swift */,
+				CEFEBC4D2C9D4330001D9A28 /* RecipeEntity.swift */,
 			);
 			path = Entity;
 			sourceTree = "<group>";
@@ -628,6 +646,7 @@
 				FE2636B42C5FF32E00B907CC /* Sources */,
 				FE2636B52C5FF32E00B907CC /* Frameworks */,
 				FE2636B62C5FF32E00B907CC /* Resources */,
+				CE5E1E3B2C9FC86A00FAF1D9 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -643,6 +662,7 @@
 				CE8FACA92C68CEBB00A1527A /* KeychainAccess */,
 				B94BAEAB2C64001F00B043B7 /* Lottie */,
 				CE4F9EA32C8F4C410060EA44 /* DropDown */,
+				CE3D90412CA018080054F3E0 /* RealmSwift */,
 			);
 			productName = Recipe;
 			productReference = FE2636B82C5FF32E00B907CC /* Recipe.app */;
@@ -680,6 +700,7 @@
 				CE8FACA82C68CEBB00A1527A /* XCRemoteSwiftPackageReference "KeychainAccess" */,
 				B94BAEAA2C64001F00B043B7 /* XCRemoteSwiftPackageReference "lottie-spm" */,
 				CE91AE662C8EF84900D3FB58 /* XCRemoteSwiftPackageReference "DropDown" */,
+				CE3D90402CA018080054F3E0 /* XCRemoteSwiftPackageReference "realm-swift" */,
 			);
 			productRefGroup = FE2636B92C5FF32E00B907CC /* Products */;
 			projectDirPath = "";
@@ -729,6 +750,7 @@
 			files = (
 				786896CC2C63CE020038B60C /* UIFlexibleGridViewItem.swift in Sources */,
 				786896C82C63803A0038B60C /* UIView.swift in Sources */,
+				CEFEBC4E2C9D4330001D9A28 /* RecipeEntity.swift in Sources */,
 				E1A276842C66915B0056D225 /* String.swift in Sources */,
 				FE2636C02C5FF32E00B907CC /* BaseViewController.swift in Sources */,
 				786896DD2C63DD3F0038B60C /* PersonalizeGoalsCell.swift in Sources */,
@@ -1028,6 +1050,14 @@
 				minimumVersion = 4.5.0;
 			};
 		};
+		CE3D90402CA018080054F3E0 /* XCRemoteSwiftPackageReference "realm-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/realm/realm-swift.git";
+			requirement = {
+				kind = exactVersion;
+				version = 10.40.0;
+			};
+		};
 		CE8A6D592C661CA600DE54C5 /* XCRemoteSwiftPackageReference "Alamofire" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Alamofire/Alamofire.git";
@@ -1083,6 +1113,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = B94BAEAA2C64001F00B043B7 /* XCRemoteSwiftPackageReference "lottie-spm" */;
 			productName = Lottie;
+		};
+		CE3D90412CA018080054F3E0 /* RealmSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CE3D90402CA018080054F3E0 /* XCRemoteSwiftPackageReference "realm-swift" */;
+			productName = RealmSwift;
 		};
 		CE4F9EA32C8F4C410060EA44 /* DropDown */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Recipe/Recipe.xcodeproj/project.pbxproj
+++ b/Recipe/Recipe.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		B94BAEAC2C64001F00B043B7 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = B94BAEAB2C64001F00B043B7 /* Lottie */; };
 		B94BAEAE2C64015300B043B7 /* splashAnimation.json in Resources */ = {isa = PBXBuildFile; fileRef = B94BAEAD2C64015300B043B7 /* splashAnimation.json */; };
 		CE4E86B82C667A9C0082E5AD /* AlamofireRecipeEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4E86B72C667A9C0082E5AD /* AlamofireRecipeEndpoint.swift */; };
+		CE4F9EA42C8F4C410060EA44 /* DropDown in Frameworks */ = {isa = PBXBuildFile; productRef = CE4F9EA32C8F4C410060EA44 /* DropDown */; };
 		CE6364712C67507B00944D1F /* LoginRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6364702C67507B00944D1F /* LoginRequest.swift */; };
 		CE6364732C67521C00944D1F /* LoginResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6364722C67521C00944D1F /* LoginResponse.swift */; };
 		CE8A6D5B2C661CA600DE54C5 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = CE8A6D5A2C661CA600DE54C5 /* Alamofire */; };
@@ -46,6 +47,14 @@
 		CE8A6D602C661D3F00DE54C5 /* AlamofireNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8A6D5F2C661D3F00DE54C5 /* AlamofireNetwork.swift */; };
 		CE8FACA72C68CDEE00A1527A /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8FACA62C68CDEE00A1527A /* KeychainManager.swift */; };
 		CE8FACAA2C68CEBB00A1527A /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = CE8FACA92C68CEBB00A1527A /* KeychainAccess */; };
+		CE91AE532C8EF3FA00D3FB58 /* CartVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE91AE4B2C8EF3F900D3FB58 /* CartVC.swift */; };
+		CE91AE602C8EF59700D3FB58 /* CategoryTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE91AE5A2C8EF59600D3FB58 /* CategoryTableViewCell.xib */; };
+		CE91AE612C8EF59700D3FB58 /* CategoryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE91AE5B2C8EF59600D3FB58 /* CategoryTableViewCell.swift */; };
+		CE91AE622C8EF59700D3FB58 /* RecipeCardViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE91AE5C2C8EF59600D3FB58 /* RecipeCardViewCell.xib */; };
+		CE91AE632C8EF59700D3FB58 /* RecipeCardCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE91AE5D2C8EF59600D3FB58 /* RecipeCardCell.xib */; };
+		CE91AE642C8EF59700D3FB58 /* RecipeCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE91AE5E2C8EF59700D3FB58 /* RecipeCardCell.swift */; };
+		CE91AE652C8EF59700D3FB58 /* RecipeCardViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE91AE5F2C8EF59700D3FB58 /* RecipeCardViewCell.swift */; };
+		CE91AE682C8F008700D3FB58 /* Recipe.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE91AE672C8F008600D3FB58 /* Recipe.swift */; };
 		CEA024EC2C65049A00CA0CF7 /* EmailLoginVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA024EA2C65049A00CA0CF7 /* EmailLoginVC.swift */; };
 		CEA024ED2C65049A00CA0CF7 /* EmailLoginVC.xib in Resources */ = {isa = PBXBuildFile; fileRef = CEA024EB2C65049A00CA0CF7 /* EmailLoginVC.xib */; };
 		CEA024EF2C65152500CA0CF7 /* CustomPasswordTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA024EE2C65152500CA0CF7 /* CustomPasswordTextField.swift */; };
@@ -121,6 +130,14 @@
 		CE8A6D5D2C661D2F00DE54C5 /* AlamofireEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlamofireEndpoint.swift; sourceTree = "<group>"; };
 		CE8A6D5F2C661D3F00DE54C5 /* AlamofireNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlamofireNetwork.swift; sourceTree = "<group>"; };
 		CE8FACA62C68CDEE00A1527A /* KeychainManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainManager.swift; sourceTree = "<group>"; };
+		CE91AE4B2C8EF3F900D3FB58 /* CartVC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CartVC.swift; sourceTree = "<group>"; };
+		CE91AE5A2C8EF59600D3FB58 /* CategoryTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = CategoryTableViewCell.xib; sourceTree = "<group>"; };
+		CE91AE5B2C8EF59600D3FB58 /* CategoryTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CategoryTableViewCell.swift; sourceTree = "<group>"; };
+		CE91AE5C2C8EF59600D3FB58 /* RecipeCardViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = RecipeCardViewCell.xib; sourceTree = "<group>"; };
+		CE91AE5D2C8EF59600D3FB58 /* RecipeCardCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = RecipeCardCell.xib; sourceTree = "<group>"; };
+		CE91AE5E2C8EF59700D3FB58 /* RecipeCardCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecipeCardCell.swift; sourceTree = "<group>"; };
+		CE91AE5F2C8EF59700D3FB58 /* RecipeCardViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecipeCardViewCell.swift; sourceTree = "<group>"; };
+		CE91AE672C8F008600D3FB58 /* Recipe.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Recipe.swift; sourceTree = "<group>"; };
 		CEA024EA2C65049A00CA0CF7 /* EmailLoginVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailLoginVC.swift; sourceTree = "<group>"; };
 		CEA024EB2C65049A00CA0CF7 /* EmailLoginVC.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EmailLoginVC.xib; sourceTree = "<group>"; };
 		CEA024EE2C65152500CA0CF7 /* CustomPasswordTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPasswordTextField.swift; sourceTree = "<group>"; };
@@ -168,6 +185,7 @@
 				E1E1FDF52C6782C900862CFC /* FacebookCore in Frameworks */,
 				E1E1FDF72C6782C900862CFC /* FacebookLogin in Frameworks */,
 				CE8A6D5B2C661CA600DE54C5 /* Alamofire in Frameworks */,
+				CE4F9EA42C8F4C410060EA44 /* DropDown in Frameworks */,
 				CE8FACAA2C68CEBB00A1527A /* KeychainAccess in Frameworks */,
 				B94BAEAC2C64001F00B043B7 /* Lottie in Frameworks */,
 			);
@@ -206,6 +224,7 @@
 			isa = PBXGroup;
 			children = (
 				786896D02C63D8E60038B60C /* DummyData.swift */,
+				CE91AE672C8F008600D3FB58 /* Recipe.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -326,6 +345,13 @@
 			path = remote;
 			sourceTree = "<group>";
 		};
+		CE4F9EA22C8F4C410060EA44 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		CE63646F2C67506300944D1F /* Requests */ = {
 			isa = PBXGroup;
 			children = (
@@ -353,6 +379,28 @@
 				CE8FACA62C68CDEE00A1527A /* KeychainManager.swift */,
 			);
 			path = local;
+			sourceTree = "<group>";
+		};
+		CE91AE482C8EEFA200D3FB58 /* Cart */ = {
+			isa = PBXGroup;
+			children = (
+				CE91AE592C8EF57700D3FB58 /* Cell */,
+				CE91AE4B2C8EF3F900D3FB58 /* CartVC.swift */,
+			);
+			path = Cart;
+			sourceTree = "<group>";
+		};
+		CE91AE592C8EF57700D3FB58 /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+				CE91AE5B2C8EF59600D3FB58 /* CategoryTableViewCell.swift */,
+				CE91AE5A2C8EF59600D3FB58 /* CategoryTableViewCell.xib */,
+				CE91AE5E2C8EF59700D3FB58 /* RecipeCardCell.swift */,
+				CE91AE5D2C8EF59600D3FB58 /* RecipeCardCell.xib */,
+				CE91AE5F2C8EF59700D3FB58 /* RecipeCardViewCell.swift */,
+				CE91AE5C2C8EF59600D3FB58 /* RecipeCardViewCell.xib */,
+			);
+			path = Cell;
 			sourceTree = "<group>";
 		};
 		CEA024E02C65038600CA0CF7 /* LoginSelect */ = {
@@ -476,6 +524,7 @@
 			children = (
 				FE2636BA2C5FF32E00B907CC /* Recipe */,
 				FE2636B92C5FF32E00B907CC /* Products */,
+				CE4F9EA22C8F4C410060EA44 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -519,6 +568,7 @@
 		FE2636D02C5FF34800B907CC /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				CE91AE482C8EEFA200D3FB58 /* Cart */,
 				E1C5A6D82C67660A0035ABC8 /* SignupOptions */,
 				E1A276782C665A830056D225 /* SignUp */,
 				786896BD2C637D2E0038B60C /* CollectionView */,
@@ -589,6 +639,7 @@
 				CE8A6D5A2C661CA600DE54C5 /* Alamofire */,
 				CE8FACA92C68CEBB00A1527A /* KeychainAccess */,
 				B94BAEAB2C64001F00B043B7 /* Lottie */,
+				CE4F9EA32C8F4C410060EA44 /* DropDown */,
 			);
 			productName = Recipe;
 			productReference = FE2636B82C5FF32E00B907CC /* Recipe.app */;
@@ -625,6 +676,7 @@
 				CE8A6D592C661CA600DE54C5 /* XCRemoteSwiftPackageReference "Alamofire" */,
 				CE8FACA82C68CEBB00A1527A /* XCRemoteSwiftPackageReference "KeychainAccess" */,
 				B94BAEAA2C64001F00B043B7 /* XCRemoteSwiftPackageReference "lottie-spm" */,
+				CE91AE662C8EF84900D3FB58 /* XCRemoteSwiftPackageReference "DropDown" */,
 			);
 			productRefGroup = FE2636B92C5FF32E00B907CC /* Products */;
 			projectDirPath = "";
@@ -650,13 +702,16 @@
 				786896D82C63DA870038B60C /* PersonalizeGoalsVC.xib in Resources */,
 				FE2636E02C5FF76800B907CC /* Poppins-SemiBold.ttf in Resources */,
 				CEAD430D2C6500610058B337 /* LoginSelectVC.xib in Resources */,
+				CE91AE622C8EF59700D3FB58 /* RecipeCardViewCell.xib in Resources */,
 				FE2636C82C5FF32F00B907CC /* Base in Resources */,
+				CE91AE602C8EF59700D3FB58 /* CategoryTableViewCell.xib in Resources */,
 				B94BAEAE2C64015300B043B7 /* splashAnimation.json in Resources */,
 				FE2636C32C5FF32E00B907CC /* Base in Resources */,
 				78607D172C6124EC008AA26B /* PersonalizeOptionVC.xib in Resources */,
 				B94BAEA12C63ECBE00B043B7 /* color.xcassets in Resources */,
 				B94BAE922C6331C800B043B7 /* OnBoardingVC.xib in Resources */,
 				FE2636E12C5FF76800B907CC /* Poppins-Medium.ttf in Resources */,
+				CE91AE632C8EF59700D3FB58 /* RecipeCardCell.xib in Resources */,
 				786896DE2C63DD3F0038B60C /* PersonalizeGoalsCell.xib in Resources */,
 				CEA024ED2C65049A00CA0CF7 /* EmailLoginVC.xib in Resources */,
 			);
@@ -698,10 +753,12 @@
 				E1A276862C6691C10056D225 /* Regex.swift in Sources */,
 				E1A2767F2C665CC10056D225 /* SignupVC.swift in Sources */,
 				CEC6BC472C677A2E0033A30E /* AuthRepository.swift in Sources */,
+				CE91AE682C8F008700D3FB58 /* Recipe.swift in Sources */,
 				CEAD430C2C6500610058B337 /* LoginSelectVC.swift in Sources */,
 				CEBB3F242C676C7000042C52 /* RegisterRequest.swift in Sources */,
 				CE4E86B82C667A9C0082E5AD /* AlamofireRecipeEndpoint.swift in Sources */,
 				CEA024F12C65182800CA0CF7 /* MaterialTextField.swift in Sources */,
+				CE91AE642C8EF59700D3FB58 /* RecipeCardCell.swift in Sources */,
 				CE6364732C67521C00944D1F /* LoginResponse.swift in Sources */,
 				CE8A6D5E2C661D2F00DE54C5 /* AlamofireEndpoint.swift in Sources */,
 				CEA024F82C6611E200CA0CF7 /* ValidationService.swift in Sources */,
@@ -711,9 +768,11 @@
 				78607D182C6124EC008AA26B /* PersonalizeOptionVC.swift in Sources */,
 				786896C62C637DF20038B60C /* NSObject.swift in Sources */,
 				786896C42C637DBB0038B60C /* UICollectionView.swift in Sources */,
+				CE91AE612C8EF59700D3FB58 /* CategoryTableViewCell.swift in Sources */,
 				FE2636BE2C5FF32E00B907CC /* SceneDelegate.swift in Sources */,
 				E1A276772C665A600056D225 /* FloatingLabelInput.swift in Sources */,
 				CEBB3F222C6768A600042C52 /* RecipeRequestInterceptor.swift in Sources */,
+				CE91AE652C8EF59700D3FB58 /* RecipeCardViewCell.swift in Sources */,
 				B94BAE9A2C634EB200B043B7 /* OnBoardingCell.swift in Sources */,
 				FE2636C02C5FF32E00B907CC /* BaseViewController.swift in Sources */,
 				7880082F2C627F2F00AA1EEA /* UIColor.swift in Sources */,
@@ -726,6 +785,7 @@
 				78607D182C6124EC008AA26B /* PersonalizeOptionVC.swift in Sources */,
 				FE2636BE2C5FF32E00B907CC /* SceneDelegate.swift in Sources */,
 				B94BAE932C6331C800B043B7 /* OnBoardingVC.swift in Sources */,
+				CE91AE532C8EF3FA00D3FB58 /* CartVC.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -980,6 +1040,14 @@
 				kind = branch;
 			};
 		};
+		CE91AE662C8EF84900D3FB58 /* XCRemoteSwiftPackageReference "DropDown" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/AssistoLab/DropDown.git";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
 		E1E1FDF32C6782C900862CFC /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/facebook/facebook-ios-sdk";
@@ -1011,6 +1079,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = B94BAEAA2C64001F00B043B7 /* XCRemoteSwiftPackageReference "lottie-spm" */;
 			productName = Lottie;
+		};
+		CE4F9EA32C8F4C410060EA44 /* DropDown */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CE91AE662C8EF84900D3FB58 /* XCRemoteSwiftPackageReference "DropDown" */;
+			productName = DropDown;
 		};
 		CE8A6D5A2C661CA600DE54C5 /* Alamofire */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Recipe/Recipe.xcodeproj/project.pbxproj
+++ b/Recipe/Recipe.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		B94BAEAE2C64015300B043B7 /* splashAnimation.json in Resources */ = {isa = PBXBuildFile; fileRef = B94BAEAD2C64015300B043B7 /* splashAnimation.json */; };
 		CE29006F2CA6B0D200AF20DE /* RealmRecipeDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE29006E2CA6B0D200AF20DE /* RealmRecipeDataSource.swift */; };
 		CE2900712CA6B39600AF20DE /* RecipeRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2900702CA6B39600AF20DE /* RecipeRepository.swift */; };
+		CE39393C2CB3EF5200811B8B /* SDWebImage in Frameworks */ = {isa = PBXBuildFile; productRef = CE39393B2CB3EF5200811B8B /* SDWebImage */; };
 		CE3D90422CA018080054F3E0 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = CE3D90412CA018080054F3E0 /* RealmSwift */; };
 		CE4E86B82C667A9C0082E5AD /* AlamofireRecipeEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4E86B72C667A9C0082E5AD /* AlamofireRecipeEndpoint.swift */; };
 		CE4F9EA42C8F4C410060EA44 /* DropDown in Frameworks */ = {isa = PBXBuildFile; productRef = CE4F9EA32C8F4C410060EA44 /* DropDown */; };
@@ -206,6 +207,7 @@
 				E1E1FDFA2C6782F700862CFC /* GoogleSignIn in Frameworks */,
 				E1E1FDF52C6782C900862CFC /* FacebookCore in Frameworks */,
 				CE3D90422CA018080054F3E0 /* RealmSwift in Frameworks */,
+				CE39393C2CB3EF5200811B8B /* SDWebImage in Frameworks */,
 				E1E1FDF72C6782C900862CFC /* FacebookLogin in Frameworks */,
 				CE8A6D5B2C661CA600DE54C5 /* Alamofire in Frameworks */,
 				CE4F9EA42C8F4C410060EA44 /* DropDown in Frameworks */,
@@ -669,6 +671,7 @@
 				B94BAEAB2C64001F00B043B7 /* Lottie */,
 				CE4F9EA32C8F4C410060EA44 /* DropDown */,
 				CE3D90412CA018080054F3E0 /* RealmSwift */,
+				CE39393B2CB3EF5200811B8B /* SDWebImage */,
 			);
 			productName = Recipe;
 			productReference = FE2636B82C5FF32E00B907CC /* Recipe.app */;
@@ -707,6 +710,7 @@
 				B94BAEAA2C64001F00B043B7 /* XCRemoteSwiftPackageReference "lottie-spm" */,
 				CE91AE662C8EF84900D3FB58 /* XCRemoteSwiftPackageReference "DropDown" */,
 				CE3D90402CA018080054F3E0 /* XCRemoteSwiftPackageReference "realm-swift" */,
+				CE1E77BD2CB3E58D0093C0C8 /* XCRemoteSwiftPackageReference "SDWebImage" */,
 			);
 			productRefGroup = FE2636B92C5FF32E00B907CC /* Products */;
 			projectDirPath = "";
@@ -1058,6 +1062,14 @@
 				minimumVersion = 4.5.0;
 			};
 		};
+		CE1E77BD2CB3E58D0093C0C8 /* XCRemoteSwiftPackageReference "SDWebImage" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/SDWebImage/SDWebImage.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
+			};
+		};
 		CE3D90402CA018080054F3E0 /* XCRemoteSwiftPackageReference "realm-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/realm/realm-swift.git";
@@ -1121,6 +1133,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = B94BAEAA2C64001F00B043B7 /* XCRemoteSwiftPackageReference "lottie-spm" */;
 			productName = Lottie;
+		};
+		CE39393B2CB3EF5200811B8B /* SDWebImage */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CE1E77BD2CB3E58D0093C0C8 /* XCRemoteSwiftPackageReference "SDWebImage" */;
+			productName = SDWebImage;
 		};
 		CE3D90412CA018080054F3E0 /* RealmSwift */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Recipe/Recipe.xcodeproj/project.pbxproj
+++ b/Recipe/Recipe.xcodeproj/project.pbxproj
@@ -409,8 +409,8 @@
 			isa = PBXGroup;
 			children = (
 				CE91AE592C8EF57700D3FB58 /* Cell */,
-				CE91AE4B2C8EF3F900D3FB58 /* CartVC.swift */,
 				CEB44CB72C9C262C00545B41 /* CartVM.swift */,
+				CE91AE4B2C8EF3F900D3FB58 /* CartVC.swift */,
 			);
 			path = Cart;
 			sourceTree = "<group>";

--- a/Recipe/Recipe.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Recipe/Recipe.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -107,6 +107,15 @@
         "revision" : "9ce8cf2c6cc1a7539e9feb1b5b85da6d20219ff5",
         "version" : "10.40.0"
       }
+    },
+    {
+      "identity" : "sdwebimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SDWebImage/SDWebImage.git",
+      "state" : {
+        "revision" : "8a1be70a625683bc04d6903e2935bf23f3c6d609",
+        "version" : "5.19.7"
+      }
     }
   ],
   "version" : 2

--- a/Recipe/Recipe.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Recipe/Recipe.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -89,6 +89,24 @@
         "revision" : "b842598f1295f3ffa1475b1580672d1fe5b83580",
         "version" : "4.5.0"
       }
+    },
+    {
+      "identity" : "realm-core",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/realm/realm-core.git",
+      "state" : {
+        "revision" : "36b2df44453ba5e830369c76ab0683799a287605",
+        "version" : "13.13.0"
+      }
+    },
+    {
+      "identity" : "realm-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/realm/realm-swift.git",
+      "state" : {
+        "revision" : "9ce8cf2c6cc1a7539e9feb1b5b85da6d20219ff5",
+        "version" : "10.40.0"
+      }
     }
   ],
   "version" : 2

--- a/Recipe/Recipe.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Recipe/Recipe.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,4 @@
 {
-  "originHash" : "fc58d0ceb96873ebfe7336296a0b14f30001dea955412054fdaa096b721c2b04",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -17,6 +16,15 @@
       "state" : {
         "revision" : "c89ed571ae140f8eb1142735e6e23d7bb8c34cb2",
         "version" : "1.7.5"
+      }
+    },
+    {
+      "identity" : "dropdown",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/AssistoLab/DropDown.git",
+      "state" : {
+        "branch" : "master",
+        "revision" : "2ab6f6ce19f0117d1a76ea043ef8f57722c65d16"
       }
     },
     {
@@ -83,5 +91,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/Recipe/Recipe/Application/AppDelegate.swift
+++ b/Recipe/Recipe/Application/AppDelegate.swift
@@ -9,7 +9,7 @@ import UIKit
 import IQKeyboardManagerSwift
 import GoogleSignIn
 import FacebookCore
-
+import RealmSwift
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -19,6 +19,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         IQKeyboardManager.shared.enable = true
+        let config = Realm.Configuration(schemaVersion: 1)
+        Realm.Configuration.defaultConfiguration = config
+        print(Realm.Configuration.defaultConfiguration.fileURL!)
         ApplicationDelegate.shared.application(
                     application,
                     didFinishLaunchingWithOptions: launchOptions

--- a/Recipe/Recipe/Data/DataSources/local/RealmRecipeDataSource.swift
+++ b/Recipe/Recipe/Data/DataSources/local/RealmRecipeDataSource.swift
@@ -50,4 +50,18 @@ class RealmRecipeDataSource {
             print("Something went wrong!")
         }
     }
+    
+    func deleteRecipeById(byId recipeId: String, complection: @escaping (Result<Void, Error>) -> Void) {
+        if let recipeToDelete = realm.object(ofType: RecipeObject.self, forPrimaryKey: recipeId) {
+            try! realm.write {
+                if recipeToDelete.isInvalidated {
+                    print("DEBUG: Object is Invalidated")
+                } else {
+                    realm.delete(recipeToDelete)
+                    print("DEBUG: Object delted successful")
+                }
+            }
+            complection(.success(()))
+        }
+    }
 }

--- a/Recipe/Recipe/Data/DataSources/local/RealmRecipeDataSource.swift
+++ b/Recipe/Recipe/Data/DataSources/local/RealmRecipeDataSource.swift
@@ -1,0 +1,53 @@
+//
+//  RealmRecipeDataSource.swift
+//  Recipe
+//
+//  Created by user on 27/09/2024.
+//
+
+import Foundation
+import RealmSwift
+
+class RealmRecipeDataSource {
+    private let realm = try! Realm()
+    
+    func fetchRecipe(complection: @escaping (Result<[RecipeObject], Error>) -> Void) {
+        let recipes = realm.objects(RecipeObject.self)
+        complection(.success(Array(recipes)))
+    }
+    
+    func addRecipe(_ recipe: RecipeObject, complection: @escaping (Result<Void, Error>) -> Void) {
+        do {
+            try realm.write {
+                realm.add(recipe, update: .modified)
+            }
+            complection(.success(()))
+        } catch {
+            complection(.failure(error))
+        }
+    }
+    
+    func deleteAllRecipe(complection: @escaping (Result<Void, Error>) -> Void) {
+        do {
+            let allRecipes = realm.objects(RecipeObject.self)
+            try realm.write {
+                realm.delete(allRecipes)
+            }
+            complection(.success(()))
+        } catch {
+            complection(.failure(error))
+        }
+    }
+    
+    func doneIngredientById(ingredientId: String, isDone: Bool) -> Void{
+        do {
+            try realm.write {
+                if let ingredientObject = realm.object(ofType: IngredientObject.self, forPrimaryKey: ingredientId) {
+                    ingredientObject.isDone = isDone
+                }
+            }
+        } catch {
+            print("Something went wrong!")
+        }
+    }
+}

--- a/Recipe/Recipe/Data/Entity/RecipeEntity.swift
+++ b/Recipe/Recipe/Data/Entity/RecipeEntity.swift
@@ -12,6 +12,7 @@ class IngredientObject: Object {
     @Persisted var id: String
     @Persisted var name: String
     @Persisted var quantity: String
+    @Persisted var quantityPerServing: String
     @Persisted var category: String
     @Persisted var isDone: Bool
     

--- a/Recipe/Recipe/Data/Entity/RecipeEntity.swift
+++ b/Recipe/Recipe/Data/Entity/RecipeEntity.swift
@@ -1,0 +1,34 @@
+//
+//  RecipeEntity.swift
+//  Recipe
+//
+//  Created by user on 20/09/2024.
+//
+
+import Foundation
+import RealmSwift
+
+class IngredientObject: Object {
+    @Persisted var id: String
+    @Persisted var name: String
+    @Persisted var quantity: String
+    @Persisted var category: String
+    @Persisted var isDone: Bool
+    
+    override class func primaryKey() -> String? {
+        return "id"
+    }
+}
+
+class RecipeObject: Object {
+    @Persisted var id: String
+    @Persisted var name: String
+    @Persisted var imageURL: String
+    @Persisted var servings: Int
+    @Persisted var ingredients = List<IngredientObject>()
+    
+    override class func primaryKey() -> String? {
+        return "id"
+    }
+}
+

--- a/Recipe/Recipe/Data/Models/Recipe.swift
+++ b/Recipe/Recipe/Data/Models/Recipe.swift
@@ -32,16 +32,16 @@ struct Recipe: Codable {
                    imageURL: "https://example.com/cauliflower_rice.jpg",
                    servings: 4,
                    ingredients: [
-                        Ingredient(id: "ing1",
-                                   name: "Ground Bee",
+                        Ingredient(id: "ingredient1",
+                                   name: "Ground Beef",
                                    IngreimageUrl: "",
-                                   quantityPerServing: "",
+                                   quantityPerServing: "0.25 lb",
                                    quantity: "1 lb",
                                    category: "Meat & Seafood", checked: ""),
-                        Ingredient(id: "ing2",
+                        Ingredient(id: "ingredient2",
                                    name: "Olive Oil",
                                    IngreimageUrl: "",
-                                   quantityPerServing: "",
+                                   quantityPerServing: "0.5 tbsp",
                                    quantity: "2 tbsp",
                                    category: "Oil & Dressings", checked: "")
                    ]
@@ -60,7 +60,7 @@ struct Recipe: Codable {
                     Ingredient(id: "ing3",
                                name: "Soy Sauce",
                                IngreimageUrl: "",
-                               quantityPerServing: "",
+                               quantityPerServing: "1.5 tbsp",
                                quantity: "3 tbsp",
                                category: "Spices & Seasonings", checked: ""),
                    ]

--- a/Recipe/Recipe/Data/Models/Recipe.swift
+++ b/Recipe/Recipe/Data/Models/Recipe.swift
@@ -51,12 +51,12 @@ struct Recipe: Codable {
                    imageURL: "https://example.com/korean_beef.jpg",
                    servings: 2,
                    ingredients: [
-                    Ingredient(id: "ing1",
-                               name: "Ground Bee",
-                               IngreimageUrl: "",
-                               quantityPerServing: "",
-                               quantity: "1 lb",
-                               category: "Meat & Seafood", checked: ""),
+//                    Ingredient(id: "ing1",
+//                               name: "Ground Bee",
+//                               IngreimageUrl: "",
+//                               quantityPerServing: "",
+//                               quantity: "1 lb",
+//                               category: "Meat & Seafood", checked: ""),
                     Ingredient(id: "ing3",
                                name: "Soy Sauce",
                                IngreimageUrl: "",
@@ -65,28 +65,28 @@ struct Recipe: Codable {
                                category: "Spices & Seasonings", checked: ""),
                    ]
             ),
-            Recipe(id: "recipe3",
-                   name: "HtanMinKyaw",
-                   imageURL: "https://example.com/cauliflower_rice.jpg",
-                   servings: 8,
-                   ingredients: [
-                    Ingredient(id: "ing1",
-                               name: "MM Foods",
-                               IngreimageUrl: "",
-                               quantityPerServing: "",
-                               quantity: "1 lb",
-                               category: "Meat & Seafood",
-                               checked: ""
-                              ),
-                   ]
-            ),
+//            Recipe(id: "recipe3",
+//                   name: "HtanMinKyaw",
+//                   imageURL: "https://example.com/cauliflower_rice.jpg",
+//                   servings: 8,
+//                   ingredients: [
+//                    Ingredient(id: "ing1",
+//                               name: "MM Foods",
+//                               IngreimageUrl: "",
+//                               quantityPerServing: "",
+//                               quantity: "1 lb",
+//                               category: "Meat & Seafood",
+//                               checked: ""
+//                              ),
+//                   ]
+//            ),
         ]
     }
 }
 
 // MARK: - Ingredient
 struct Ingredient: Codable {
-    let id,
+    var id,
         name,
         IngreimageUrl,
         quantityPerServing,

--- a/Recipe/Recipe/Data/Models/Recipe.swift
+++ b/Recipe/Recipe/Data/Models/Recipe.swift
@@ -52,7 +52,7 @@ struct Recipe: Codable {
                    servings: 2,
                    ingredients: [
 //                    Ingredient(id: "ing1",
-//                               name: "Ground Bee",
+//                               name: "Ground Beef",
 //                               IngreimageUrl: "",
 //                               quantityPerServing: "",
 //                               quantity: "1 lb",

--- a/Recipe/Recipe/Data/Repositories/RecipeRepository.swift
+++ b/Recipe/Recipe/Data/Repositories/RecipeRepository.swift
@@ -35,4 +35,8 @@ class RecipeRepository: RecipeRepositoryProtocol {
     func doneIngredientById(ingredientId: String, isDone: Bool) {
         realmDataSource.doneIngredientById(ingredientId: ingredientId, isDone: isDone)
     }
+    
+    func deleteRecipeById(byId recipeId: String, complection: @escaping (Result<Void, Error>) -> Void) {
+        realmDataSource.deleteRecipeById(byId: recipeId, complection: complection)
+    }
 }

--- a/Recipe/Recipe/Data/Repositories/RecipeRepository.swift
+++ b/Recipe/Recipe/Data/Repositories/RecipeRepository.swift
@@ -1,0 +1,38 @@
+//
+//  RecipeRepository.swift
+//  Recipe
+//
+//  Created by user on 27/09/2024.
+//
+
+import Foundation
+
+protocol RecipeRepositoryProtocol {
+    func getRecipe(completion: @escaping (Result<[RecipeObject], Error>) -> Void)
+    func addRecipe(_ recipe: RecipeObject, completion: @escaping (Result<Void, Error>) -> Void)
+    func deleteAllRecipe(complection: @escaping (Result<Void, Error>) -> Void)
+}
+
+class RecipeRepository: RecipeRepositoryProtocol {
+    private let realmDataSource: RealmRecipeDataSource
+    
+    init(realmDataSource: RealmRecipeDataSource) {
+        self.realmDataSource = realmDataSource
+    }
+    
+    func getRecipe(completion: @escaping (Result<[RecipeObject], Error>) -> Void) {
+        realmDataSource.fetchRecipe(complection: completion)
+    }
+    
+    func addRecipe(_ recipe: RecipeObject, completion: @escaping (Result<Void, Error>) -> Void) {
+        realmDataSource.addRecipe(recipe, complection: completion)
+    }
+    
+    func deleteAllRecipe(complection: @escaping (Result<Void, Error>) -> Void) {
+        realmDataSource.deleteAllRecipe(complection: complection)
+    }
+    
+    func doneIngredientById(ingredientId: String, isDone: Bool) {
+        realmDataSource.doneIngredientById(ingredientId: ingredientId, isDone: isDone)
+    }
+}

--- a/Recipe/Recipe/Model/Recipe.swift
+++ b/Recipe/Recipe/Model/Recipe.swift
@@ -1,0 +1,96 @@
+//
+//  Recipe.swift
+//  Recipe
+//
+//  Created by user(PaingLoop) on 18/08/2024.
+//
+
+import UIKit
+
+// MARK: - Results
+struct Results: Codable {
+    let recipes: [Recipe]
+}
+
+// MARK: - Recipe
+struct Recipe: Codable {
+    let id, name: String
+    let imageURL: String
+    let servings: Int
+    var ingredients: [Ingredient]
+
+    enum CodingKeys: String, CodingKey {
+        case id, name
+        case imageURL = "imageUrl"
+        case servings, ingredients
+    }
+    
+    static func dummyRecipeData() -> [Recipe] {
+        return [
+            Recipe(id: "recipe1",
+                   name: "Cajun Spiced Cauliflower Rice",
+                   imageURL: "https://example.com/cauliflower_rice.jpg",
+                   servings: 4,
+                   ingredients: [
+                        Ingredient(id: "ing1",
+                                   name: "Ground Bee",
+                                   IngreimageUrl: "",
+                                   quantityPerServing: "",
+                                   quantity: "1 lb",
+                                   category: "Meat & Seafood", checked: ""),
+                        Ingredient(id: "ing2",
+                                   name: "Olive Oil",
+                                   IngreimageUrl: "",
+                                   quantityPerServing: "",
+                                   quantity: "2 tbsp",
+                                   category: "Oil & Dressings", checked: "")
+                   ]
+            ),
+            Recipe(id: "recipe2",
+                   name: "Easy Korean Beef",
+                   imageURL: "https://example.com/korean_beef.jpg",
+                   servings: 2,
+                   ingredients: [
+                    Ingredient(id: "ing1",
+                               name: "Ground Bee",
+                               IngreimageUrl: "",
+                               quantityPerServing: "",
+                               quantity: "1 lb",
+                               category: "Meat & Seafood", checked: ""),
+                    Ingredient(id: "ing3",
+                               name: "Soy Sauce",
+                               IngreimageUrl: "",
+                               quantityPerServing: "",
+                               quantity: "3 tbsp",
+                               category: "Spices & Seasonings", checked: ""),
+                   ]
+            ),
+            Recipe(id: "recipe3",
+                   name: "HtanMinKyaw",
+                   imageURL: "https://example.com/cauliflower_rice.jpg",
+                   servings: 8,
+                   ingredients: [
+                    Ingredient(id: "ing1",
+                               name: "MM Foods",
+                               IngreimageUrl: "",
+                               quantityPerServing: "",
+                               quantity: "1 lb",
+                               category: "Meat & Seafood",
+                               checked: ""
+                              ),
+                   ]
+            ),
+        ]
+    }
+}
+
+// MARK: - Ingredient
+struct Ingredient: Codable {
+    let id,
+        name,
+        IngreimageUrl,
+        quantityPerServing,
+        quantity,
+        category: String,
+        checked: String
+}

--- a/Recipe/Recipe/Resources/Assets.xcassets/navigation-color.colorset/Contents.json
+++ b/Recipe/Recipe/Resources/Assets.xcassets/navigation-color.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.424",
+          "green" : "0.416",
+          "red" : "0.239"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Recipe/Recipe/Views/Cart/CartVC.swift
+++ b/Recipe/Recipe/Views/Cart/CartVC.swift
@@ -53,7 +53,7 @@ class CartVC: UIViewController {
         tableView.showsVerticalScrollIndicator = false
         tableView.showsHorizontalScrollIndicator = false
         
-        if !vm.realm.isEmpty {
+        if !vm.recipeObjects.isEmpty {
             registerCells()
         }
     }
@@ -62,7 +62,7 @@ class CartVC: UIViewController {
         let categoryTableViewCellNib = UINib(nibName: "CategoryTableViewCell", bundle: nil)
         
         let headerView = Bundle.main.loadNibNamed("RecipeCardCell", owner: self, options: nil)?.first as? RecipeCardCell
-        headerView?.configure(with: vm.dummyRecipeData)
+        headerView?.configure(with: vm.recipeObjects, vm: self.vm)
         tableView.tableHeaderView = headerView
         tableView.register(categoryTableViewCellNib, forCellReuseIdentifier: "CategoryTableViewCell")
     }
@@ -124,7 +124,7 @@ class CartVC: UIViewController {
         
         actionSheet.addAction(UIAlertAction(title: "Clear List", style: .default, handler: { _ in
             print("DEBUG: Delete All Realm Data")
-            // self.vm.deleteAllData()
+            self.vm.deleteAllData()
         }))
         actionSheet.addAction(UIAlertAction(title: "Share Ingredient List", style: .default, handler: { _ in
             print("Option 2 selected")

--- a/Recipe/Recipe/Views/Cart/CartVC.swift
+++ b/Recipe/Recipe/Views/Cart/CartVC.swift
@@ -1,0 +1,244 @@
+//
+//  CartVC.swift
+//  Recipe
+//
+//  Created by user(PaingLoop) on 17/08/2024.
+//
+
+import UIKit
+
+class CartVC: UIViewController {
+    
+    // MARK: Properties
+    private let tableView = UITableView(frame: .zero, style: .grouped)
+    var dummyRecipeData = Recipe.dummyRecipeData()
+    var ingredientsByCategory: [(String, [(Recipe, Ingredient)])] = []
+    var doneIngredients: [(Recipe, Ingredient, originalSection: Int, originalIndex: Int)] = []
+    
+    // MARK: LifeCycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureUI()
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        if dummyRecipeData.isEmpty {
+            showNoDataView()
+        }
+    }
+    
+    // MARK: UI Configuration
+    private func configureUI() {
+        title = "My Groceries"
+        setupTableView()
+        setupNavigationBar()
+        groupIngredientsByCategory()
+    }
+    
+    private func setupTableView() {
+        view.addSubview(tableView)
+        tableView.frame = view.bounds
+        tableView.delegate = self
+        tableView.dataSource = self
+        tableView.separatorStyle = .none
+        tableView.showsVerticalScrollIndicator = false
+        tableView.showsHorizontalScrollIndicator = false
+        
+        if !dummyRecipeData.isEmpty {
+            registerCells()
+        }
+    }
+    
+    private func registerCells() {
+        let categoryTableViewCellNib = UINib(nibName: "CategoryTableViewCell", bundle: nil)
+        let headerView = Bundle.main.loadNibNamed("RecipeCardCell", owner: self, options: nil)?.first as? RecipeCardCell
+        headerView?.configure(with: dummyRecipeData)
+        tableView.tableHeaderView = headerView
+        tableView.register(categoryTableViewCellNib, forCellReuseIdentifier: "CategoryTableViewCell")
+    }
+    
+    private func setupNavigationBar() {
+        
+        navigationController?.isNavigationBarHidden = false
+        
+        let navigationBarAppearance = UINavigationBarAppearance()
+        navigationBarAppearance.configureWithDefaultBackground()
+        navigationBarAppearance.backgroundColor = UIColor(named: "navigation-color")
+        navigationBarAppearance.shadowColor = .clear
+        
+        navigationItem.standardAppearance = navigationBarAppearance
+        navigationItem.compactAppearance = navigationBarAppearance
+        navigationItem.scrollEdgeAppearance = navigationBarAppearance
+        
+        navigationController?.navigationBar.tintColor = .label
+        navigationController?.navigationBar.prefersLargeTitles = true
+        
+        navigationItem.rightBarButtonItems = [
+            UIBarButtonItem(image: UIImage(systemName: "person"), style: .done, target: self, action: #selector(showActionSheet))
+        ]
+    }
+    
+    private func groupIngredientsByCategory() {
+        var tempDict = [String: [(Recipe, Ingredient)]]()
+        
+        for recipe in dummyRecipeData {
+            for ingredient in recipe.ingredients {
+                tempDict[ingredient.category, default: []].append((recipe, ingredient))
+            }
+        }
+        
+        ingredientsByCategory = tempDict.sorted(by: { $0.key < $1.key })
+    }
+    
+    // MARK: No Data View
+    func showNoDataView() {
+        let noDataView = UIView(frame: tableView.bounds)
+        noDataView.backgroundColor = UIColor(named: "navigation-color")
+        
+        let imageView = UIImageView(image: UIImage(named: "no_data_image"))
+        imageView.contentMode = .scaleAspectFit
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        
+        let label = UILabel()
+        label.text = "Data Not Found"
+        label.textAlignment = .center
+        label.textColor = .label
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        noDataView.addSubview(imageView)
+        noDataView.addSubview(label)
+        
+        NSLayoutConstraint.activate([
+            imageView.centerXAnchor.constraint(equalTo: noDataView.centerXAnchor),
+            imageView.centerYAnchor.constraint(equalTo: noDataView.centerYAnchor, constant: -20),
+            imageView.widthAnchor.constraint(equalToConstant: 100),
+            imageView.heightAnchor.constraint(equalToConstant: 100),
+            label.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: 50),
+            label.centerXAnchor.constraint(equalTo: noDataView.centerXAnchor)
+        ])
+        
+        tableView.backgroundView = noDataView
+    }
+    
+    // MARK: Selector
+    @objc func showActionSheet() {
+        let actionSheet = UIAlertController(title: "Choose an Option", message: "Select one of the following actions", preferredStyle: .actionSheet)
+        
+        actionSheet.addAction(UIAlertAction(title: "Clear List", style: .default, handler: { _ in
+            print("Option 1 selected")
+        }))
+        actionSheet.addAction(UIAlertAction(title: "Share Ingredient List", style: .default, handler: { _ in
+            print("Option 2 selected")
+        }))
+        actionSheet.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        actionSheet.view.tintColor = .label
+        
+        present(actionSheet, animated: true, completion: nil)
+    }
+    
+    func handleCheckboxTap(at indexPath: IndexPath) {
+        var selectedIngredient: (Recipe, Ingredient)
+        
+        if indexPath.section < ingredientsByCategory.count {
+            // Move from the original section to "Done"
+            selectedIngredient = ingredientsByCategory[indexPath.section].1.remove(at: indexPath.row)
+            doneIngredients.append((selectedIngredient.0, selectedIngredient.1, indexPath.section, indexPath.row))
+            
+            // Remove empty sections if necessary
+            if ingredientsByCategory[indexPath.section].1.isEmpty {
+                ingredientsByCategory.remove(at: indexPath.section)
+            }
+        } else {
+            // Move back from "Done" to the original section
+            let (recipe, ingredient, originalSection, originalIndex) = doneIngredients.remove(at: indexPath.row)
+            
+            if originalSection < ingredientsByCategory.count {
+                ingredientsByCategory[originalSection].1.insert((recipe, ingredient), at: originalIndex)
+            } else {
+                ingredientsByCategory.append((ingredient.category, [(recipe, ingredient)]))
+                ingredientsByCategory.sort(by: { $0.0 < $1.0 }) // Ensure sections remain sorted
+            }
+        }
+        
+        // Reload the table view to reflect the changes
+        tableView.reloadData()    }
+}
+
+// MARK: Extensions
+extension CartVC: UITableViewDelegate, UITableViewDataSource {
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: CategoryTableViewCell.identifier, for: indexPath) as? CategoryTableViewCell else {
+            return UITableViewCell()
+        }
+        
+        if indexPath.section < ingredientsByCategory.count {
+            let (recipe, ingredient) = ingredientsByCategory[indexPath.section].1[indexPath.row]
+            cell.configure(with: recipe, ingredient: ingredient, isDone: false)
+            cell.setActiveStyle()
+        } else {
+            let (recipe, ingredient, _, _) = doneIngredients[indexPath.row]
+            cell.configure(with: recipe, ingredient: ingredient, isDone: true)
+            UIView.animate(withDuration: 0.5) {
+                cell.setInactiveStyle()
+            }
+        }
+        
+        cell.checkboxTapped = { [weak self] in
+            self?.handleCheckboxTap(at: indexPath)
+        }
+        
+        return cell
+    }
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        if section < ingredientsByCategory.count {
+            return ingredientsByCategory[section].1.count
+        } else {
+            return doneIngredients.count
+        }
+    }
+    
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        if section < ingredientsByCategory.count {
+            return ingredientsByCategory[section].0
+        } else {
+            return "Done"
+        }
+    }
+    
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return ingredientsByCategory.count + (doneIngredients.isEmpty ? 0 : 1)
+    }
+    
+//    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+//        tableView.deselectRow(at: indexPath, animated: true)
+//
+//        // var selectedIngredient: (Recipe, Ingredient)
+//
+//        if indexPath.section < ingredientsByCategory.count {
+//            let (recipe, ingredient) = ingredientsByCategory[indexPath.section].1.remove(at: indexPath.row)
+//
+//            doneIngredients.append((recipe, ingredient, indexPath.section, indexPath.row))
+//
+//            // Remove empty sections if necessary
+//            if ingredientsByCategory[indexPath.section].1.isEmpty {
+//                ingredientsByCategory.remove(at: indexPath.section)
+//            }
+//        } else {
+//            let (recipe, ingredient, originalSection, originalIndex) = doneIngredients.remove(at: indexPath.row)
+//            // If the original section still exists
+//            if originalSection < ingredientsByCategory.count {
+//                ingredientsByCategory[originalSection].1.insert((recipe, ingredient), at: originalIndex)
+//            } else {
+//                // If the original section was removed, recreate it
+//                ingredientsByCategory.append((ingredient.category, [(recipe, ingredient)]))
+//                ingredientsByCategory.sort(by: { $0.0 < $1.0 }) // Ensure sections are sorted
+//            }
+//        }
+//
+//        // Reload the table view to reflect the changes
+//        tableView.reloadData()
+//    }
+}

--- a/Recipe/Recipe/Views/Cart/CartVC.swift
+++ b/Recipe/Recipe/Views/Cart/CartVC.swift
@@ -24,21 +24,12 @@ class CartVC: UIViewController {
         super.viewDidLayoutSubviews()
     }
     
-    deinit {
-        NotificationCenter.default.removeObserver(self, name: NSNotification.Name("IngredientQuantityUpdated"), object: nil)
-        NotificationCenter.default.removeObserver(self, name: NSNotification.Name("RecipeDeleted"), object: nil)
-    }
-    
     // MARK: UI Configuration
     private func configureUI() {
         title = "My Groceries"
         setupTableView()
         setupNavigationBar()
-        
-        NotificationCenter.default.addObserver(self, selector: #selector(reloadData), name: NSNotification.Name("IngredientQuantityUpdated"), object: nil)
-        
-        NotificationCenter.default.addObserver(self, selector: #selector(recipeDelete), name: NSNotification.Name("RecipeDeleted"), object: nil)
-        
+    
         vm.onIngredientsChanged = { [weak self] in
             self?.tableView.reloadData()
         }
@@ -68,13 +59,13 @@ class CartVC: UIViewController {
         let categoryTableViewCellNib = UINib(nibName: "CategoryTableViewCell", bundle: nil)
         
         headerView = Bundle.main.loadNibNamed("RecipeCardCell", owner: self, options: nil)?.first as? RecipeCardCell
-        headerView?.configure(with: vm.recipeObjects)
+        headerView?.configure(with: vm.recipeObjects, delegate: self)
         tableView.tableHeaderView = headerView
         tableView.register(categoryTableViewCellNib, forCellReuseIdentifier: "CategoryTableViewCell")
     }
     
     private func updateHeaderView() {
-        headerView?.configure(with: vm.recipeObjects)
+        headerView?.configure(with: vm.recipeObjects, delegate: self)
     }
     
     private func setupNavigationBar() {
@@ -213,5 +204,16 @@ extension CartVC: UITableViewDelegate, UITableViewDataSource {
     
     func numberOfSections(in tableView: UITableView) -> Int {
         return vm.numberOfSections()
+    }
+}
+extension CartVC: RecipeCardViewCellDelegate {
+    func didUpdateIngredientQuantity(forRecipeId recipeId: String, newQuantity: String) {
+        vm.updateIngredientQuantity(recipeId: recipeId, newQuantity: newQuantity)
+        self.reloadData()
+    }
+
+    func didTapDeleteRecipe(with recipeId: String) {
+        vm.deleteRecipebyId(recipeId: recipeId)
+        self.recipeDelete()
     }
 }

--- a/Recipe/Recipe/Views/Cart/CartVC.swift
+++ b/Recipe/Recipe/Views/Cart/CartVC.swift
@@ -22,9 +22,6 @@ class CartVC: UIViewController {
     
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        if vm.dummyRecipeData.isEmpty {
-            showNoDataView()
-        }
     }
     
     // MARK: UI Configuration
@@ -35,6 +32,10 @@ class CartVC: UIViewController {
         
         vm.onIngredientsChanged = { [weak self] in
             self?.tableView.reloadData()
+        }
+        
+        vm.onNoData = { [weak self] in
+            self?.showNoDataView()
         }
     }
     

--- a/Recipe/Recipe/Views/Cart/CartVC.swift
+++ b/Recipe/Recipe/Views/Cart/CartVC.swift
@@ -141,16 +141,13 @@ class CartVC: UIViewController {
         var selectedIngredient: (Recipe, Ingredient)
         
         if indexPath.section < ingredientsByCategory.count {
-            // Move from the original section to "Done"
             selectedIngredient = ingredientsByCategory[indexPath.section].1.remove(at: indexPath.row)
             doneIngredients.append((selectedIngredient.0, selectedIngredient.1, indexPath.section, indexPath.row))
             
-            // Remove empty sections if necessary
             if ingredientsByCategory[indexPath.section].1.isEmpty {
                 ingredientsByCategory.remove(at: indexPath.section)
             }
         } else {
-            // Move back from "Done" to the original section
             let (recipe, ingredient, originalSection, originalIndex) = doneIngredients.remove(at: indexPath.row)
             
             if originalSection < ingredientsByCategory.count {
@@ -161,7 +158,6 @@ class CartVC: UIViewController {
             }
         }
         
-        // Reload the table view to reflect the changes
         tableView.reloadData()    }
 }
 
@@ -211,34 +207,4 @@ extension CartVC: UITableViewDelegate, UITableViewDataSource {
     func numberOfSections(in tableView: UITableView) -> Int {
         return ingredientsByCategory.count + (doneIngredients.isEmpty ? 0 : 1)
     }
-    
-//    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-//        tableView.deselectRow(at: indexPath, animated: true)
-//
-//        // var selectedIngredient: (Recipe, Ingredient)
-//
-//        if indexPath.section < ingredientsByCategory.count {
-//            let (recipe, ingredient) = ingredientsByCategory[indexPath.section].1.remove(at: indexPath.row)
-//
-//            doneIngredients.append((recipe, ingredient, indexPath.section, indexPath.row))
-//
-//            // Remove empty sections if necessary
-//            if ingredientsByCategory[indexPath.section].1.isEmpty {
-//                ingredientsByCategory.remove(at: indexPath.section)
-//            }
-//        } else {
-//            let (recipe, ingredient, originalSection, originalIndex) = doneIngredients.remove(at: indexPath.row)
-//            // If the original section still exists
-//            if originalSection < ingredientsByCategory.count {
-//                ingredientsByCategory[originalSection].1.insert((recipe, ingredient), at: originalIndex)
-//            } else {
-//                // If the original section was removed, recreate it
-//                ingredientsByCategory.append((ingredient.category, [(recipe, ingredient)]))
-//                ingredientsByCategory.sort(by: { $0.0 < $1.0 }) // Ensure sections are sorted
-//            }
-//        }
-//
-//        // Reload the table view to reflect the changes
-//        tableView.reloadData()
-//    }
 }

--- a/Recipe/Recipe/Views/Cart/CartVM.swift
+++ b/Recipe/Recipe/Views/Cart/CartVM.swift
@@ -1,0 +1,70 @@
+//
+//  CartViewModel.swift
+//  Recipe
+//
+//  Created by user on 19/09/2024.
+//
+
+import UIKit
+
+class CartVM {
+    
+    // MARK: -Properties
+    var dummyRecipeData = Recipe.dummyRecipeData()
+    var ingredientsByCategory: [(String, [(Recipe, Ingredient)])] = []
+    var doneIngredients: [(Recipe, Ingredient, originalSection: Int, originalIndex: Int)] = []
+    var onIngredientsChanged: (() -> Void)?
+    
+    init() {
+        groupIngredientsByCategory()
+    }
+    
+    private func groupIngredientsByCategory() {
+        var tempDict = [String: [(Recipe, Ingredient)]]()
+        
+        for recipe in dummyRecipeData {
+            for ingredient in recipe.ingredients {
+                tempDict[ingredient.category, default: []].append((recipe, ingredient))
+            }
+        }
+        
+        ingredientsByCategory = tempDict.sorted(by: { $0.key < $1.key })
+    }
+    
+    func handleCheckboxTap(at indexPath: IndexPath) {
+        var selectedIngredient: (Recipe, Ingredient)
+        
+        if indexPath.section < ingredientsByCategory.count {
+            selectedIngredient = ingredientsByCategory[indexPath.section].1.remove(at: indexPath.row)
+            doneIngredients.append((selectedIngredient.0, selectedIngredient.1, indexPath.section, indexPath.row))
+            
+            if ingredientsByCategory[indexPath.section].1.isEmpty {
+                ingredientsByCategory.remove(at: indexPath.section)
+            }
+        } else {
+            let (recipe, ingredient, originalSection, originalIndex) = doneIngredients.remove(at: indexPath.row)
+            
+            if originalSection < ingredientsByCategory.count {
+                ingredientsByCategory[originalSection].1.insert((recipe, ingredient), at: originalIndex)
+            } else {
+                ingredientsByCategory.append((ingredient.category, [(recipe, ingredient)]))
+                ingredientsByCategory.sort(by: { $0.0 < $1.0 }) // Ensure sections remain sorted
+            }
+        }
+        
+        onIngredientsChanged?()
+        
+    }
+    
+    func numberOfSections() -> Int {
+        return ingredientsByCategory.count + (doneIngredients.isEmpty ? 0 : 1)
+    }
+    
+    func numberOfRows(in section: Int) -> Int {
+        if section < ingredientsByCategory.count {
+            return ingredientsByCategory[section].1.count
+        } else {
+            return doneIngredients.count
+        }
+    }
+}

--- a/Recipe/Recipe/Views/Cart/CartVM.swift
+++ b/Recipe/Recipe/Views/Cart/CartVM.swift
@@ -6,17 +6,24 @@
 //
 
 import UIKit
+import RealmSwift
 
 class CartVM {
     
     // MARK: -Properties
     var dummyRecipeData = Recipe.dummyRecipeData()
-    var ingredientsByCategory: [(String, [(Recipe, Ingredient)])] = []
-    var doneIngredients: [(Recipe, Ingredient, originalSection: Int, originalIndex: Int)] = []
+    private var realm: Realm = try! Realm()
+    private(set) var ingredientsByCategory: [(String, [(Recipe, Ingredient)])] = []
+    private(set) var doneIngredients: [(Recipe, Ingredient, originalSection: Int, originalIndex: Int)] = []
     var onIngredientsChanged: (() -> Void)?
+    var onNoData: (() -> Void)?
     
     init() {
-        groupIngredientsByCategory()
+        
+//        deleteAllData()
+
+        loadRecipeDataFromRealm()
+//        groupIngredientsByCategory()
     }
     
     private func groupIngredientsByCategory() {
@@ -30,13 +37,100 @@ class CartVM {
         
         ingredientsByCategory = tempDict.sorted(by: { $0.key < $1.key })
     }
+
+    
+    private func defaultRecipeData() {
+        let dummyRecipeData = Recipe.dummyRecipeData()
+        addRecipeToRealm(dummyRecipeData)
+    }
+    
+    func loadRecipeDataFromRealm() {
+        
+        let recipes = realm.objects(RecipeObject.self)
+
+        if recipes.isEmpty {
+            // onNoData?()
+            defaultRecipeData()
+            return
+        }
+
+        var tempDict = [String: [(Recipe, Ingredient)]]()
+        doneIngredients.removeAll()
+
+        for recipeObject in recipes {
+            let recipe = Recipe(id: recipeObject.id,
+                                name: recipeObject.name,
+                                imageURL: recipeObject.imageURL,
+                                servings: recipeObject.servings,
+                                ingredients: [])
+
+            for ingredientObject in recipeObject.ingredients {
+                let ingredient = Ingredient(id: ingredientObject.id,
+                                            name: ingredientObject.name,
+                                            IngreimageUrl: "",
+                                            quantityPerServing: "",
+                                            quantity: ingredientObject.quantity,
+                                            category: ingredientObject.category,
+                                            checked: ""
+                )
+
+                if ingredientObject.isDone {
+                    doneIngredients.append((recipe, ingredient, 0, 0))
+                } else {
+                    tempDict[ingredient.category, default: []].append((recipe, ingredient))
+                }
+            }
+        }
+        ingredientsByCategory = tempDict.sorted(by: { $0.key < $1.key })
+        onIngredientsChanged?()
+    }
+    
+    func deleteAllData() {
+        try! self.realm.write {
+            realm.deleteAll()
+        }
+        
+        loadRecipeDataFromRealm()
+    }
+    
+    func addRecipeToRealm(_ recipes: [Recipe]) {
+        try! realm.write {
+            for recipe in recipes {
+                let recipeObject = RecipeObject()
+                recipeObject.id = recipe.id
+                recipeObject.name = recipe.name
+                recipeObject.imageURL = recipe.imageURL
+                recipeObject.servings = recipe.servings
+
+                for ingredient in recipe.ingredients {
+                    let ingredientObject = IngredientObject()
+                    ingredientObject.id = ingredient.id
+                    ingredientObject.name = ingredient.name
+                    ingredientObject.quantity = ingredient.quantity
+                    ingredientObject.category = ingredient.category
+                    ingredientObject.isDone = false
+                    recipeObject.ingredients.append(ingredientObject)
+                }
+                realm.add(recipeObject, update: .modified)
+            }
+        }
+
+        loadRecipeDataFromRealm()
+    }
+    
     
     func handleCheckboxTap(at indexPath: IndexPath) {
-        var selectedIngredient: (Recipe, Ingredient)
         
         if indexPath.section < ingredientsByCategory.count {
-            selectedIngredient = ingredientsByCategory[indexPath.section].1.remove(at: indexPath.row)
-            doneIngredients.append((selectedIngredient.0, selectedIngredient.1, indexPath.section, indexPath.row))
+            let (recipe, ingredient) = ingredientsByCategory[indexPath.section].1.remove(at: indexPath.row)
+            
+            try! realm.write {
+                if let ingredientObject = self.realm.object(ofType: IngredientObject.self, forPrimaryKey: ingredient.id) {
+                    ingredientObject.isDone = true
+                }
+            }
+            
+            doneIngredients.append((recipe, ingredient, indexPath.section, indexPath.row))
             
             if ingredientsByCategory[indexPath.section].1.isEmpty {
                 ingredientsByCategory.remove(at: indexPath.section)
@@ -44,16 +138,21 @@ class CartVM {
         } else {
             let (recipe, ingredient, originalSection, originalIndex) = doneIngredients.remove(at: indexPath.row)
             
+            try! realm.write {
+                if let ingredientObject = self.realm.object(ofType: IngredientObject.self, forPrimaryKey: ingredient.id) {
+                    ingredientObject.isDone = false
+                }
+            }
+            
             if originalSection < ingredientsByCategory.count {
                 ingredientsByCategory[originalSection].1.insert((recipe, ingredient), at: originalIndex)
             } else {
                 ingredientsByCategory.append((ingredient.category, [(recipe, ingredient)]))
-                ingredientsByCategory.sort(by: { $0.0 < $1.0 }) // Ensure sections remain sorted
+                ingredientsByCategory.sort(by: { $0.0 < $1.0 })
             }
         }
-        
-        onIngredientsChanged?()
-        
+//        onIngredientsChanged?()
+        loadRecipeDataFromRealm()
     }
     
     func numberOfSections() -> Int {

--- a/Recipe/Recipe/Views/Cart/CartVM.swift
+++ b/Recipe/Recipe/Views/Cart/CartVM.swift
@@ -114,6 +114,24 @@ class CartVM {
         loadRecipeDataFromRealm()
     }
     
+    func updateIngredientQuantity(recipeId: String, newQuantity: String) {
+        let realm = try! Realm()
+        let newQuantityNumber = Double(newQuantity) ?? 0.0
+        if let recipe = realm.object(ofType: RecipeObject.self, forPrimaryKey: recipeId) {
+            try! realm.write {
+                for ingredient in recipe.ingredients {
+                    let parts = ingredient.quantityPerServing.split(separator: " ")
+                    print("\(parts[0]) and \(parts[1]) quantityPerServing")
+                    let subString = parts.map { Double($0) ?? 0.0}
+                    print("\(subString[0] * newQuantityNumber)")
+                    let updatedQuantity = subString[0] * newQuantityNumber
+                    
+                    ingredient.quantity = "\(updatedQuantity) \(parts[1])"
+                }
+            }
+        }
+    }
+    
     func deleteRecipebyId(recipeId: String) {
         if let index = recipeObjects.firstIndex(where: {$0.id == recipeId}) {
             recipeObjects.remove(at: index)

--- a/Recipe/Recipe/Views/Cart/CartVM.swift
+++ b/Recipe/Recipe/Views/Cart/CartVM.swift
@@ -1,5 +1,5 @@
 //
-//  CartViewModel.swift
+//  CartVM.swift
 //  Recipe
 //
 //  Created by user on 19/09/2024.
@@ -12,20 +12,32 @@ class CartVM {
     
     // MARK: -Properties
     var dummyRecipeData = Recipe.dummyRecipeData()
-    private var realm: Realm = try! Realm()
+    private let recipeRepository: RecipeRepository
+    var realm: Realm = try! Realm()
     private(set) var ingredientsByCategory: [(String, [(Recipe, Ingredient)])] = []
     private(set) var doneIngredients: [(Recipe, Ingredient, originalSection: Int, originalIndex: Int)] = []
     var onIngredientsChanged: (() -> Void)?
     var onNoData: (() -> Void)?
+    var recipeObj: [RecipeObject] = [RecipeObject]()
     
     init() {
+        recipeRepository = RecipeRepository(realmDataSource: RealmRecipeDataSource())
         
 //        deleteAllData()
-
-        loadRecipeDataFromRealm()
-//        groupIngredientsByCategory()
+        defaultRecipeData()
+        
+        recipeRepository.getRecipe(completion: {  [unowned self] result in
+            switch result {
+                case .success(let recipes):
+                    self.recipeObj = recipes
+                    self.loadRecipeDataFromRealm()
+                case .failure(let error):
+                    print(error.localizedDescription)
+            }
+        })
     }
     
+    //MARK: Testing Method
     private func groupIngredientsByCategory() {
         var tempDict = [String: [(Recipe, Ingredient)]]()
         
@@ -34,45 +46,48 @@ class CartVM {
                 tempDict[ingredient.category, default: []].append((recipe, ingredient))
             }
         }
-        
         ingredientsByCategory = tempDict.sorted(by: { $0.key < $1.key })
     }
-
     
     private func defaultRecipeData() {
         let dummyRecipeData = Recipe.dummyRecipeData()
         addRecipeToRealm(dummyRecipeData)
     }
     
+    func createRecipe(from recipeObject: RecipeObject) -> Recipe {
+        return Recipe(id: recipeObject.id,
+                      name: recipeObject.name,
+                      imageURL: recipeObject.imageURL,
+                      servings: recipeObject.servings,
+                      ingredients: [])
+    }
+    
+    func createIngredient(from ingredientObject: IngredientObject) -> Ingredient {
+        return Ingredient(id: ingredientObject.id,
+                          name: ingredientObject.name,
+                          IngreimageUrl: "",
+                          quantityPerServing: "",
+                          quantity: ingredientObject.quantity,
+                          category: ingredientObject.category,
+                          checked: "")
+    }
+    
     func loadRecipeDataFromRealm() {
+        let recipes = recipeObj
         
-        let recipes = realm.objects(RecipeObject.self)
-
         if recipes.isEmpty {
-            // onNoData?()
-            defaultRecipeData()
+            onNoData?()
             return
         }
-
+        
         var tempDict = [String: [(Recipe, Ingredient)]]()
         doneIngredients.removeAll()
-
+        
         for recipeObject in recipes {
-            let recipe = Recipe(id: recipeObject.id,
-                                name: recipeObject.name,
-                                imageURL: recipeObject.imageURL,
-                                servings: recipeObject.servings,
-                                ingredients: [])
-
-            for ingredientObject in recipeObject.ingredients {
-                let ingredient = Ingredient(id: ingredientObject.id,
-                                            name: ingredientObject.name,
-                                            IngreimageUrl: "",
-                                            quantityPerServing: "",
-                                            quantity: ingredientObject.quantity,
-                                            category: ingredientObject.category,
-                                            checked: ""
-                )
+            let recipe = createRecipe(from: recipeObject)
+            
+            for ingredientObject in recipeObject.ingredients.sorted(byKeyPath: "category", ascending: true) {
+                let ingredient = createIngredient(from: ingredientObject)
 
                 if ingredientObject.isDone {
                     doneIngredients.append((recipe, ingredient, 0, 0))
@@ -86,73 +101,60 @@ class CartVM {
     }
     
     func deleteAllData() {
-        try! self.realm.write {
-            realm.deleteAll()
-        }
-        
+        recipeRepository.deleteAllRecipe(complection: { result in
+            switch result {
+                case .success():
+                    print("Delete All from realm")
+                case .failure(_):
+                    print("Error: deleteAllData")
+            }
+        })
         loadRecipeDataFromRealm()
     }
     
     func addRecipeToRealm(_ recipes: [Recipe]) {
-        try! realm.write {
-            for recipe in recipes {
-                let recipeObject = RecipeObject()
-                recipeObject.id = recipe.id
-                recipeObject.name = recipe.name
-                recipeObject.imageURL = recipe.imageURL
-                recipeObject.servings = recipe.servings
-
-                for ingredient in recipe.ingredients {
-                    let ingredientObject = IngredientObject()
-                    ingredientObject.id = ingredient.id
-                    ingredientObject.name = ingredient.name
-                    ingredientObject.quantity = ingredient.quantity
-                    ingredientObject.category = ingredient.category
-                    ingredientObject.isDone = false
-                    recipeObject.ingredients.append(ingredientObject)
-                }
-                realm.add(recipeObject, update: .modified)
+        for recipe in recipes {
+            let recipeObject = RecipeObject()
+            recipeObject.id = recipe.id
+            recipeObject.name = recipe.name
+            recipeObject.imageURL = recipe.imageURL
+            recipeObject.servings = recipe.servings
+            
+            for ingredient in recipe.ingredients {
+                let ingredientObject = IngredientObject()
+                ingredientObject.id = ingredient.id
+                ingredientObject.name = ingredient.name
+                ingredientObject.quantity = ingredient.quantity
+                ingredientObject.category = ingredient.category
+                ingredientObject.isDone = false
+                recipeObject.ingredients.append(ingredientObject)
             }
+            recipeRepository.addRecipe(recipeObject, completion: { result in
+                switch result {
+                    case .success():
+                        print("add Recipe data to realmDB")
+                    case .failure(_):
+                        print("Error: Recipe data to realmDB")
+                }
+            })
         }
-
-        loadRecipeDataFromRealm()
     }
     
-    
     func handleCheckboxTap(at indexPath: IndexPath) {
-        
         if indexPath.section < ingredientsByCategory.count {
             let (recipe, ingredient) = ingredientsByCategory[indexPath.section].1.remove(at: indexPath.row)
-            
-            try! realm.write {
-                if let ingredientObject = self.realm.object(ofType: IngredientObject.self, forPrimaryKey: ingredient.id) {
-                    ingredientObject.isDone = true
-                }
-            }
-            
+            recipeRepository.doneIngredientById(ingredientId: ingredient.id, isDone: true)
             doneIngredients.append((recipe, ingredient, indexPath.section, indexPath.row))
-            
             if ingredientsByCategory[indexPath.section].1.isEmpty {
                 ingredientsByCategory.remove(at: indexPath.section)
             }
         } else {
             let (recipe, ingredient, originalSection, originalIndex) = doneIngredients.remove(at: indexPath.row)
-            
-            try! realm.write {
-                if let ingredientObject = self.realm.object(ofType: IngredientObject.self, forPrimaryKey: ingredient.id) {
-                    ingredientObject.isDone = false
-                }
-            }
-            
-            if originalSection < ingredientsByCategory.count {
-                ingredientsByCategory[originalSection].1.insert((recipe, ingredient), at: originalIndex)
-            } else {
-                ingredientsByCategory.append((ingredient.category, [(recipe, ingredient)]))
-                ingredientsByCategory.sort(by: { $0.0 < $1.0 })
-            }
+            recipeRepository.doneIngredientById(ingredientId: ingredient.id, isDone: false)
+            ingredientsByCategory.append((ingredient.category, [(recipe, ingredient)]))
+            ingredientsByCategory.sort(by: { $0.0 < $1.0 })
         }
-//        onIngredientsChanged?()
-        loadRecipeDataFromRealm()
+        onIngredientsChanged?()
     }
     
     func numberOfSections() -> Int {
@@ -167,3 +169,12 @@ class CartVM {
         }
     }
 }
+extension CartVM: IngredientCellDelegate {
+    func didUpdateQuantity(_ recipeObj: RecipeObject) {
+        try! realm.write {
+            print(recipeObj.ingredients.count)
+            onIngredientsChanged?()
+        }
+    }
+}
+

--- a/Recipe/Recipe/Views/Cart/CartVM.swift
+++ b/Recipe/Recipe/Views/Cart/CartVM.swift
@@ -149,9 +149,13 @@ class CartVM {
                 ingredientsByCategory.remove(at: indexPath.section)
             }
         } else {
-            let (recipe, ingredient, originalSection, originalIndex) = doneIngredients.remove(at: indexPath.row)
+            let (recipe, ingredient, _, originalIndex) = doneIngredients.remove(at: indexPath.row)
             recipeRepository.doneIngredientById(ingredientId: ingredient.id, isDone: false)
-            ingredientsByCategory.append((ingredient.category, [(recipe, ingredient)]))
+            if let sectionIndex = ingredientsByCategory.firstIndex(where: {$0.0 == ingredient.category}) {
+                ingredientsByCategory[sectionIndex].1.insert((recipe, ingredient), at: originalIndex)
+            } else {
+                ingredientsByCategory.append((ingredient.category, [(recipe, ingredient)]))
+            }
             ingredientsByCategory.sort(by: { $0.0 < $1.0 })
         }
         onIngredientsChanged?()

--- a/Recipe/Recipe/Views/Cart/Cell/CategoryTableViewCell.swift
+++ b/Recipe/Recipe/Views/Cart/Cell/CategoryTableViewCell.swift
@@ -1,0 +1,75 @@
+//
+//  CategoryTableViewCell.swift
+//  Recipe
+//
+//  Created by user on 24/08/2024.
+//
+
+import UIKit
+
+class CategoryTableViewCell: UITableViewCell {
+    
+    // MARK: Properties
+    
+    static let identifier = "CategoryTableViewCell"
+
+    @IBOutlet weak var recipeName: UILabel!
+    @IBOutlet weak var ingredientName: UILabel!
+    @IBOutlet weak var servingLabel: UILabel!
+    @IBOutlet weak var categoryImageView: UIImageView!
+    @IBOutlet weak var checkboxButton: UIButton!
+    
+    // MARK: Events
+    var checkboxTapped: (() -> Void)?
+    
+    @IBAction func checkboxTapped(_ sender: UIButton) {
+        checkboxTapped?()
+    }
+    
+    // MARK: LifeCycle
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        
+    }
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+
+    
+    // MARK: Configure
+    func configure(with recipe: Recipe, ingredient: Ingredient, isDone: Bool) {
+        servingLabel.text = ingredient.quantity
+        ingredientName.text = ingredient.name
+        recipeName.text = recipe.name
+        
+        let imageName = isDone ? "checkmark.circle.fill" : "checkmark.circle"
+        checkboxButton.setImage(UIImage(systemName: imageName), for: .normal)
+    }
+    
+    func setInactiveStyle() {
+        self.backgroundColor = UIColor.lightGray
+        recipeName.textColor = UIColor.darkGray
+        servingLabel.textColor = UIColor.darkGray
+        ingredientName.textColor = UIColor.darkGray
+    }
+    
+    func setActiveStyle() {
+        self.backgroundColor = UIColor.white
+        recipeName.textColor = UIColor.black
+        servingLabel.textColor = UIColor.black
+        ingredientName.textColor = UIColor.black
+    }
+}

--- a/Recipe/Recipe/Views/Cart/Cell/CategoryTableViewCell.xib
+++ b/Recipe/Recipe/Views/Cart/Cell/CategoryTableViewCell.xib
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="CategoryTableViewCell" rowHeight="77" id="KGk-i7-Jjw" customClass="CategoryTableViewCell" customModule="Recipe" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="345" height="77"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="345" height="77"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="XTq-9W-Bzs">
+                        <rect key="frame" x="10" y="10" width="60" height="60"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="60" id="2Fx-Fs-0ET"/>
+                            <constraint firstAttribute="height" constant="60" id="mfZ-Cr-A96"/>
+                        </constraints>
+                    </imageView>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="6m6-SV-Kqi">
+                        <rect key="frame" x="90.000000000000014" y="10" width="155.33333333333337" height="60"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="RecipeName                      " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7oN-A9-fsP">
+                                <rect key="frame" x="0.0" y="0.0" width="155.33333333333334" height="15.666666666666666"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="IngredientName" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1dY-77-qjF">
+                                <rect key="frame" x="0.0" y="15.666666666666668" width="155.33333333333334" height="32.333333333333329"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Serving" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="o1j-w1-tDr">
+                                <rect key="frame" x="0.0" y="48" width="155.33333333333334" height="12"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="10"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                    </stackView>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4wn-J0-gBy" userLabel="CheckBtn">
+                        <rect key="frame" x="299.33333333333331" y="27.333333333333329" width="25.666666666666686" height="25.666666666666671"/>
+                        <color key="tintColor" name="171717"/>
+                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                        <state key="normal" image="circle" catalog="system"/>
+                        <connections>
+                            <action selector="checkboxTapped:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="Qik-bs-LaN"/>
+                        </connections>
+                    </button>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="bottom" secondItem="XTq-9W-Bzs" secondAttribute="bottom" constant="10" id="1BA-y1-vqx"/>
+                    <constraint firstItem="6m6-SV-Kqi" firstAttribute="bottom" secondItem="XTq-9W-Bzs" secondAttribute="bottom" id="1GL-8k-7Mh"/>
+                    <constraint firstItem="6m6-SV-Kqi" firstAttribute="top" secondItem="XTq-9W-Bzs" secondAttribute="top" id="JEg-O2-fsj"/>
+                    <constraint firstAttribute="trailing" secondItem="4wn-J0-gBy" secondAttribute="trailing" constant="20" id="Jvr-uc-Wh9"/>
+                    <constraint firstItem="6m6-SV-Kqi" firstAttribute="leading" secondItem="XTq-9W-Bzs" secondAttribute="trailing" constant="20" id="NGG-vg-n9T"/>
+                    <constraint firstItem="XTq-9W-Bzs" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="10" id="dQu-Cf-HW2"/>
+                    <constraint firstItem="XTq-9W-Bzs" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="10" id="oZI-TY-dLW"/>
+                    <constraint firstItem="4wn-J0-gBy" firstAttribute="centerY" secondItem="XTq-9W-Bzs" secondAttribute="centerY" id="wRV-5q-gBh"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="categoryImageView" destination="XTq-9W-Bzs" id="W7w-4P-qng"/>
+                <outlet property="checkboxButton" destination="4wn-J0-gBy" id="o8a-5Y-57b"/>
+                <outlet property="ingredientName" destination="1dY-77-qjF" id="X5l-I4-k7V"/>
+                <outlet property="recipeName" destination="7oN-A9-fsP" id="caz-Xf-PYe"/>
+                <outlet property="servingLabel" destination="o1j-w1-tDr" id="ADm-ZR-Brh"/>
+            </connections>
+            <point key="canvasLocation" x="35.877862595419849" y="0.35211267605633806"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <image name="circle" catalog="system" width="128" height="123"/>
+        <namedColor name="171717">
+            <color red="0.090196078431372548" green="0.090196078431372548" blue="0.090196078431372548" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
+</document>

--- a/Recipe/Recipe/Views/Cart/Cell/CategoryTableViewCell.xib
+++ b/Recipe/Recipe/Views/Cart/Cell/CategoryTableViewCell.xib
@@ -17,7 +17,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="345" height="77"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="XTq-9W-Bzs">
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="dummy" translatesAutoresizingMaskIntoConstraints="NO" id="XTq-9W-Bzs">
                         <rect key="frame" x="10" y="10" width="60" height="60"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="60" id="2Fx-Fs-0ET"/>
@@ -81,6 +81,7 @@
     </objects>
     <resources>
         <image name="circle" catalog="system" width="128" height="123"/>
+        <image name="dummy" width="70" height="70"/>
         <namedColor name="171717">
             <color red="0.090196078431372548" green="0.090196078431372548" blue="0.090196078431372548" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/Recipe/Recipe/Views/Cart/Cell/RecipeCardCell.swift
+++ b/Recipe/Recipe/Views/Cart/Cell/RecipeCardCell.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import RealmSwift
 
 class RecipeCardCell: UITableViewCell {
     
@@ -54,12 +55,15 @@ class RecipeCardCell: UITableViewCell {
 extension RecipeCardCell: UICollectionViewDelegate, UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return Recipe.dummyRecipeData().count
+        let realm = try! Realm()
+        return realm.objects(RecipeObject.self).count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let realm = try! Realm()
+        let recipeObj = realm.objects(RecipeObject.self)
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: RecipeCardViewCell.identifier, for: indexPath) as! RecipeCardViewCell
-        cell.config(with: Recipe.dummyRecipeData()[indexPath.row])
+        cell.config(with: recipeObj[indexPath.row])
         return cell
     }
 }

--- a/Recipe/Recipe/Views/Cart/Cell/RecipeCardCell.swift
+++ b/Recipe/Recipe/Views/Cart/Cell/RecipeCardCell.swift
@@ -14,7 +14,7 @@ class RecipeCardCell: UITableViewCell {
     static let identifier = "RecipeCardCell"
     @IBOutlet weak var recipeTitle: UILabel!
     @IBOutlet weak var cartCollectionView: UICollectionView!
-    private var vm: CartVM?
+    private var vm: CartVM = CartVM.shared
     
     // MARK: LifeCycle
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -45,11 +45,11 @@ class RecipeCardCell: UITableViewCell {
     }
     
     // MARK: Configure
-    func configure(with model: [RecipeObject], vm: CartVM) {
-        self.vm = vm 
+    func configure(with model: [RecipeObject]) {
         let totalRecipes = model.count
         let totalItems = model.reduce(0) { $0 + $1.ingredients.count }
         recipeTitle.text = "\(totalRecipes) Recipes ● \(totalItems) Items"
+        cartCollectionView.reloadData()
     }
 }
 
@@ -57,14 +57,25 @@ class RecipeCardCell: UITableViewCell {
 extension RecipeCardCell: UICollectionViewDelegate, UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return vm?.recipeObjects.count ?? 0
+        if vm.recipeObjects.isEmpty {
+            return 0
+        }
+        return vm.recipeObjects.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let recipeObj = vm?.recipeObjects
+        let recipeObj = vm.recipeObjects
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: RecipeCardViewCell.identifier, for: indexPath) as! RecipeCardViewCell
-        cell.config(with: (recipeObj?[indexPath.row])!)
+        cell.config(with: recipeObj[indexPath.row])
         return cell
+    }
+    
+    private func updateUIForEmptyState() {
+        if vm.recipeObjects.isEmpty {
+            cartCollectionView.isHidden = true 
+        } else {
+            cartCollectionView.isHidden = false
+        }
     }
 }
 

--- a/Recipe/Recipe/Views/Cart/Cell/RecipeCardCell.swift
+++ b/Recipe/Recipe/Views/Cart/Cell/RecipeCardCell.swift
@@ -1,0 +1,81 @@
+//
+//  RecipeCardCell.swift
+//  Recipe
+//
+//  Created by user on 21/08/2024.
+//
+
+import UIKit
+
+class RecipeCardCell: UITableViewCell {
+    
+    // MARK: Properties
+    static let identifier = "RecipeCardCell"
+    @IBOutlet weak var recipeTitle: UILabel!
+    @IBOutlet weak var cartCollectionView: UICollectionView!
+    
+    // MARK: LifeCycle
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        setupCollectionView()
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        cartCollectionView.frame = CGRect(x: 0, y: 0, width: contentView.bounds.width - 10, height: 250)
+    }
+    
+    // MARK: Setup Methods
+    private func setupCollectionView() {
+        cartCollectionView.register(UINib(nibName: "RecipeCardViewCell", bundle: nil), forCellWithReuseIdentifier: RecipeCardViewCell.identifier)
+        cartCollectionView.delegate = self
+        cartCollectionView.dataSource = self
+        cartCollectionView.contentInset = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
+        selectionStyle = .none
+    }
+    
+    // MARK: Configure
+    func configure(with model: [Recipe]) {
+        let totalRecipes = model.count
+        let totalItems = model.reduce(0) { $0 + $1.ingredients.count }
+        recipeTitle.text = "\(totalRecipes) Recipes ● \(totalItems) Items"
+    }
+}
+
+// MARK: UICollectionView Delegate & DataSource
+extension RecipeCardCell: UICollectionViewDelegate, UICollectionViewDataSource {
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return Recipe.dummyRecipeData().count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: RecipeCardViewCell.identifier, for: indexPath) as! RecipeCardViewCell
+        cell.config(with: Recipe.dummyRecipeData()[indexPath.row])
+        return cell
+    }
+}
+
+// MARK: UICollectionView DelegateFlowLayout
+extension RecipeCardCell: UICollectionViewDelegateFlowLayout {
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return CGSize(width: 200, height: 200)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        return 16
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
+        return 8
+    }
+}

--- a/Recipe/Recipe/Views/Cart/Cell/RecipeCardCell.swift
+++ b/Recipe/Recipe/Views/Cart/Cell/RecipeCardCell.swift
@@ -14,6 +14,7 @@ class RecipeCardCell: UITableViewCell {
     static let identifier = "RecipeCardCell"
     @IBOutlet weak var recipeTitle: UILabel!
     @IBOutlet weak var cartCollectionView: UICollectionView!
+    private var vm: CartVM?
     
     // MARK: LifeCycle
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -44,7 +45,8 @@ class RecipeCardCell: UITableViewCell {
     }
     
     // MARK: Configure
-    func configure(with model: [Recipe]) {
+    func configure(with model: [RecipeObject], vm: CartVM) {
+        self.vm = vm 
         let totalRecipes = model.count
         let totalItems = model.reduce(0) { $0 + $1.ingredients.count }
         recipeTitle.text = "\(totalRecipes) Recipes ● \(totalItems) Items"
@@ -55,15 +57,13 @@ class RecipeCardCell: UITableViewCell {
 extension RecipeCardCell: UICollectionViewDelegate, UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        let realm = try! Realm()
-        return realm.objects(RecipeObject.self).count
+        return vm?.recipeObjects.count ?? 0
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let realm = try! Realm()
-        let recipeObj = realm.objects(RecipeObject.self)
+        let recipeObj = vm?.recipeObjects
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: RecipeCardViewCell.identifier, for: indexPath) as! RecipeCardViewCell
-        cell.config(with: recipeObj[indexPath.row])
+        cell.config(with: (recipeObj?[indexPath.row])!)
         return cell
     }
 }

--- a/Recipe/Recipe/Views/Cart/Cell/RecipeCardCell.swift
+++ b/Recipe/Recipe/Views/Cart/Cell/RecipeCardCell.swift
@@ -15,6 +15,7 @@ class RecipeCardCell: UITableViewCell {
     @IBOutlet weak var recipeTitle: UILabel!
     @IBOutlet weak var cartCollectionView: UICollectionView!
     private var vm: CartVM = CartVM.shared
+    private weak var delegate: RecipeCardViewCellDelegate?
     
     // MARK: LifeCycle
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -28,11 +29,17 @@ class RecipeCardCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         setupCollectionView()
+        setupShadow()
+    }
+    
+    private func setupShadow() {
+        contentView.dropShadow()
     }
     
     override func layoutSubviews() {
         super.layoutSubviews()
         cartCollectionView.frame = CGRect(x: 0, y: 0, width: contentView.bounds.width - 10, height: 250)
+        contentView.layer.shadowPath = UIBezierPath(rect: contentView.bounds).cgPath
     }
     
     // MARK: Setup Methods
@@ -45,11 +52,12 @@ class RecipeCardCell: UITableViewCell {
     }
     
     // MARK: Configure
-    func configure(with model: [RecipeObject]) {
+    func configure(with model: [RecipeObject], delegate: RecipeCardViewCellDelegate) {
         let totalRecipes = model.count
         let totalItems = model.reduce(0) { $0 + $1.ingredients.count }
         recipeTitle.text = "\(totalRecipes) Recipes ● \(totalItems) Items"
         cartCollectionView.reloadData()
+        self.delegate = delegate
     }
 }
 
@@ -66,7 +74,7 @@ extension RecipeCardCell: UICollectionViewDelegate, UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let recipeObj = vm.recipeObjects
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: RecipeCardViewCell.identifier, for: indexPath) as! RecipeCardViewCell
-        cell.config(with: recipeObj[indexPath.row])
+        cell.config(with: recipeObj[indexPath.row], delegate: self.delegate)
         return cell
     }
     

--- a/Recipe/Recipe/Views/Cart/Cell/RecipeCardCell.xib
+++ b/Recipe/Recipe/Views/Cart/Cell/RecipeCardCell.xib
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="325" id="KGk-i7-Jjw" customClass="RecipeCardCell" customModule="Recipe" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="443" height="325"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="443" height="325"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="faz-4G-eOc">
+                        <rect key="frame" x="10" y="10" width="423" height="54"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="M1l-Jk-mZ7">
+                        <rect key="frame" x="0.0" y="79" width="443" height="230"/>
+                        <color key="backgroundColor" name="navigation-color"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="230" id="12W-QS-PBd"/>
+                        </constraints>
+                        <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="10" id="H7Z-My-xP3">
+                            <size key="itemSize" width="128" height="128"/>
+                            <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                            <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                            <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                        </collectionViewFlowLayout>
+                    </collectionView>
+                </subviews>
+                <color key="backgroundColor" name="navigation-color"/>
+                <constraints>
+                    <constraint firstAttribute="trailing" secondItem="M1l-Jk-mZ7" secondAttribute="trailing" id="4JK-cX-1Al"/>
+                    <constraint firstItem="faz-4G-eOc" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="10" id="6DG-u5-IGf"/>
+                    <constraint firstItem="faz-4G-eOc" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="10" id="IAh-Sb-n8u"/>
+                    <constraint firstAttribute="bottom" secondItem="M1l-Jk-mZ7" secondAttribute="bottom" constant="16" id="L0X-eV-6dD"/>
+                    <constraint firstItem="M1l-Jk-mZ7" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="dRO-N7-Aqu"/>
+                    <constraint firstItem="M1l-Jk-mZ7" firstAttribute="top" secondItem="faz-4G-eOc" secondAttribute="bottom" constant="15" id="ncc-yO-Xay"/>
+                    <constraint firstAttribute="trailing" secondItem="faz-4G-eOc" secondAttribute="trailing" constant="10" id="yo0-hk-XF4"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="cartCollectionView" destination="M1l-Jk-mZ7" id="E6s-m6-Hml"/>
+                <outlet property="recipeTitle" destination="faz-4G-eOc" id="uPC-Uf-jJZ"/>
+            </connections>
+            <point key="canvasLocation" x="194.6564885496183" y="66.549295774647888"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <namedColor name="navigation-color">
+            <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
+</document>

--- a/Recipe/Recipe/Views/Cart/Cell/RecipeCardViewCell.swift
+++ b/Recipe/Recipe/Views/Cart/Cell/RecipeCardViewCell.swift
@@ -22,8 +22,10 @@ class RecipeCardViewCell: UICollectionViewCell {
     
     private let options = ["1", "2", "3", "4", "5", "6", "8", "10", "12", "14"]
     private var dropDown = DropDown()
-    
-    private var ingredient: Ingredient?
+    private let dropDownWidth = 80.0
+
+    private var vm: CartVM?
+    private var recipe: RecipeObject?
     
     // MARK: LifeCycle Methods
     override func awakeFromNib() {
@@ -33,18 +35,21 @@ class RecipeCardViewCell: UICollectionViewCell {
     
     override func layoutSubviews() {
         super.layoutSubviews()
-        configureShadow()
     }
     
     // MARK: - Setup Methods
     private func setupUI() {
         cardImageView.layer.cornerRadius = 10
         selectDropdownMenuButton.addTarget(self, action: #selector(toggleDropdown), for: .touchUpInside)
+        
+        closeButton.addTarget(self, action: #selector(deleteRecipe), for: .touchUpInside)
     }
     
     private func setupDropdown(_ recipe: RecipeObject) {
         dropDown.dataSource = options
         dropDown.anchorView = selectDropdownMenuButton
+        dropDown.width = dropDownWidth
+        dropDown.backgroundColor = UIColor.white.withAlphaComponent(0.95)
         dropDown.selectionAction = { [unowned self] (index: Int, item: String) in
             selectPeopleLabel.text = item
             updateIngredientQuantity(recipeId: recipe.id, newQuantity: item)
@@ -57,8 +62,8 @@ class RecipeCardViewCell: UICollectionViewCell {
         if let recipe = realm.object(ofType: RecipeObject.self, forPrimaryKey: recipeId) {
             try! realm.write {
                 for ingredient in recipe.ingredients {
-                    let parts = ingredient.quantity.split(separator: " ")
-                    print("\(parts[0]) and \(parts[1])")
+                    let parts = ingredient.quantityPerServing.split(separator: " ")
+                    print("\(parts[0]) and \(parts[1]) quantityPerServing")
                     let subString = parts.map { Double($0) ?? 0.0}
                     print("\(subString[0] * newQuantityNumber)")
                     let updatedQuantity = subString[0] * newQuantityNumber
@@ -70,18 +75,13 @@ class RecipeCardViewCell: UICollectionViewCell {
         }
     }
     
-    private func configureShadow() {
-        layer.masksToBounds = false
-        layer.shadowColor = UIColor.black.cgColor
-        layer.shadowOpacity = 0.5
-        layer.shadowOffset = CGSize(width: 0, height: 0)
-        layer.shadowRadius = 1
-        layer.shadowPath = UIBezierPath(roundedRect: bounds, cornerRadius: 10).cgPath
-    }
-    
     // MARK: - Selector
     @objc private func toggleDropdown() {
         dropDown.show()
+    }
+    
+    @objc private func deleteRecipe() {
+        
     }
     
     // MARK: - Configuration

--- a/Recipe/Recipe/Views/Cart/Cell/RecipeCardViewCell.swift
+++ b/Recipe/Recipe/Views/Cart/Cell/RecipeCardViewCell.swift
@@ -87,8 +87,7 @@ class RecipeCardViewCell: UICollectionViewCell {
     // MARK: - Configuration
     func config(with recipe: RecipeObject) {
         titleLabel.text = recipe.name
-        cardImageView.image = UIImage(named: "SignupBg")
-        
+        cardImageView.image = UIImage(named: "SignupBg") // temporary used
         setupDropdown(recipe)
     }
 }

--- a/Recipe/Recipe/Views/Cart/Cell/RecipeCardViewCell.swift
+++ b/Recipe/Recipe/Views/Cart/Cell/RecipeCardViewCell.swift
@@ -1,0 +1,70 @@
+//
+//  RecipeCardViewCell.swift
+//  Recipe
+//
+//  Created by user on 22/08/2024.
+//
+
+import UIKit
+import DropDown
+
+class RecipeCardViewCell: UICollectionViewCell {
+    
+    // MARK: Properties
+    static let identifier = "RecipeCardViewCell"
+    
+    @IBOutlet weak var cardImageView: UIImageView!
+    @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet weak var selectPeopleLabel: UILabel!
+    @IBOutlet weak var selectDropdownMenuButton: UIButton!
+    @IBOutlet weak var closeButton: UIButton!
+    
+    private let options = ["1", "2", "3", "4", "5", "6", "8", "10", "12", "14"]
+    private var dropDown = DropDown()
+    
+    // MARK: LifeCycle Methods
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        setupUI()
+        setupDropdown()
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        configureShadow()
+    }
+    
+    // MARK: - Setup Methods
+    private func setupUI() {
+        cardImageView.layer.cornerRadius = 10
+        selectDropdownMenuButton.addTarget(self, action: #selector(toggleDropdown), for: .touchUpInside)
+    }
+    
+    private func setupDropdown() {
+        dropDown.dataSource = options
+        dropDown.anchorView = selectDropdownMenuButton
+        dropDown.selectionAction = { [unowned self] (index: Int, item: String) in
+            selectPeopleLabel.text = item
+        }
+    }
+    
+    private func configureShadow() {
+        layer.masksToBounds = false
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOpacity = 0.5
+        layer.shadowOffset = CGSize(width: 0, height: 0)
+        layer.shadowRadius = 1
+        layer.shadowPath = UIBezierPath(roundedRect: bounds, cornerRadius: 10).cgPath
+    }
+    
+    // MARK: - Selector
+    @objc private func toggleDropdown() {
+        dropDown.show()
+    }
+    
+    // MARK: - Configuration
+    func config(with recipe: Recipe) {
+        titleLabel.text = recipe.name
+        cardImageView.image = UIImage(named: "SignupBg")
+    }
+}

--- a/Recipe/Recipe/Views/Cart/Cell/RecipeCardViewCell.swift
+++ b/Recipe/Recipe/Views/Cart/Cell/RecipeCardViewCell.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import DropDown
+import RealmSwift
 
 class RecipeCardViewCell: UICollectionViewCell {
     
@@ -22,11 +23,12 @@ class RecipeCardViewCell: UICollectionViewCell {
     private let options = ["1", "2", "3", "4", "5", "6", "8", "10", "12", "14"]
     private var dropDown = DropDown()
     
+    private var ingredient: Ingredient?
+    
     // MARK: LifeCycle Methods
     override func awakeFromNib() {
         super.awakeFromNib()
         setupUI()
-        setupDropdown()
     }
     
     override func layoutSubviews() {
@@ -40,11 +42,31 @@ class RecipeCardViewCell: UICollectionViewCell {
         selectDropdownMenuButton.addTarget(self, action: #selector(toggleDropdown), for: .touchUpInside)
     }
     
-    private func setupDropdown() {
+    private func setupDropdown(_ recipe: RecipeObject) {
         dropDown.dataSource = options
         dropDown.anchorView = selectDropdownMenuButton
         dropDown.selectionAction = { [unowned self] (index: Int, item: String) in
             selectPeopleLabel.text = item
+            updateIngredientQuantity(recipeId: recipe.id, newQuantity: item)
+        }
+    }
+    
+    func updateIngredientQuantity(recipeId: String, newQuantity: String) {
+        let realm = try! Realm()
+        let newQuantityNumber = Double(newQuantity) ?? 0.0
+        if let recipe = realm.object(ofType: RecipeObject.self, forPrimaryKey: recipeId) {
+            try! realm.write {
+                for ingredient in recipe.ingredients {
+                    let parts = ingredient.quantity.split(separator: " ")
+                    print("\(parts[0]) and \(parts[1])")
+                    let subString = parts.map { Double($0) ?? 0.0}
+                    print("\(subString[0] * newQuantityNumber)")
+                    let updatedQuantity = subString[0] * newQuantityNumber
+                    
+                    ingredient.quantity = "\(updatedQuantity) \(parts[1])"
+                }
+                NotificationCenter.default.post(name: NSNotification.Name("IngredientQuantityUpdated"), object: nil)
+            }
         }
     }
     
@@ -63,8 +85,10 @@ class RecipeCardViewCell: UICollectionViewCell {
     }
     
     // MARK: - Configuration
-    func config(with recipe: Recipe) {
+    func config(with recipe: RecipeObject) {
         titleLabel.text = recipe.name
         cardImageView.image = UIImage(named: "SignupBg")
+        
+        setupDropdown(recipe)
     }
 }

--- a/Recipe/Recipe/Views/Cart/Cell/RecipeCardViewCell.swift
+++ b/Recipe/Recipe/Views/Cart/Cell/RecipeCardViewCell.swift
@@ -8,6 +8,7 @@
 import UIKit
 import DropDown
 import RealmSwift
+import SDWebImage
 
 class RecipeCardViewCell: UICollectionViewCell {
     
@@ -24,7 +25,7 @@ class RecipeCardViewCell: UICollectionViewCell {
     private var dropDown = DropDown()
     private let dropDownWidth = 80.0
 
-    private var vm: CartVM?
+    private var vm: CartVM = CartVM.shared
     private var recipe: RecipeObject?
     
     // MARK: LifeCycle Methods
@@ -81,13 +82,21 @@ class RecipeCardViewCell: UICollectionViewCell {
     }
     
     @objc private func deleteRecipe() {
-        
+        guard let recipeId = recipe?.id else { return }
+        print("DEBUG: Deleting recipe with id \(recipeId)")
+        vm.deleteRecipebyId(recipeId: recipeId)
+        NotificationCenter.default.post(name: NSNotification.Name("RecipeDeleted"), object: nil)
     }
     
     // MARK: - Configuration
     func config(with recipe: RecipeObject) {
         titleLabel.text = recipe.name
-        cardImageView.image = UIImage(named: "SignupBg") // temporary used
+        if let imageUrl = URL(string: recipe.imageURL) {
+            cardImageView.sd_setImage(with: imageUrl)
+        } else {
+            cardImageView.image = UIImage(named: "SignupBg")
+        }
         setupDropdown(recipe)
+        self.recipe = recipe
     }
 }

--- a/Recipe/Recipe/Views/Cart/Cell/RecipeCardViewCell.xib
+++ b/Recipe/Recipe/Views/Cart/Cell/RecipeCardViewCell.xib
@@ -14,7 +14,7 @@
         <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="RecipeCardViewCell" rowHeight="239" id="KGk-i7-Jjw" customClass="RecipeCardViewCell" customModule="Recipe" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="208" height="239"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" alpha="0.59999999999999998" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
                 <rect key="frame" x="0.0" y="0.0" width="208" height="239"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
@@ -29,6 +29,7 @@
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="top" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iKi-OH-VrL">
                                 <rect key="frame" x="0.0" y="0.0" width="198" height="20.333333333333332"/>
+                                <color key="tintColor" systemColor="labelColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -50,7 +51,7 @@
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="person" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="lE0-lJ-Jp2" userLabel="personImg">
                                         <rect key="frame" x="0.0" y="1.6666666666666652" width="18" height="15.333333333333336"/>
-                                        <color key="tintColor" systemColor="systemBackgroundColor"/>
+                                        <color key="tintColor" name="EBF0F7"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="18" id="8oL-kO-fVW"/>
                                             <constraint firstAttribute="height" constant="18" id="PaK-5p-V6Q"/>
@@ -68,7 +69,7 @@
                                         <constraints>
                                             <constraint firstAttribute="width" constant="20" id="9tg-3X-ash"/>
                                         </constraints>
-                                        <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <color key="tintColor" name="EBF0F7"/>
                                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                         <state key="normal" title="⌵"/>
                                     </button>
@@ -81,14 +82,16 @@
                             <constraint firstAttribute="width" constant="60" id="xSi-2C-nTY"/>
                         </constraints>
                     </view>
-                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ezm-Y1-Ivn">
-                        <rect key="frame" x="170" y="5" width="30" height="20"/>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ezm-Y1-Ivn">
+                        <rect key="frame" x="178.33333333333334" y="5" width="21.666666666666657" height="20"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="20" id="9hL-Bc-TFP"/>
                         </constraints>
                         <color key="tintColor" name="EBF0F7"/>
                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                        <state key="normal" title="⌦"/>
+                        <state key="normal" image="delete.left" catalog="system">
+                            <color key="titleColor" systemColor="labelColor"/>
+                        </state>
                     </button>
                 </subviews>
                 <constraints>
@@ -117,7 +120,8 @@
         </tableViewCell>
     </objects>
     <resources>
-        <image name="person" catalog="system" width="32" height="32"/>
+        <image name="delete.left" catalog="system" width="128" height="102"/>
+        <image name="person" catalog="system" width="128" height="121"/>
         <namedColor name="171717">
             <color red="0.090196078431372548" green="0.090196078431372548" blue="0.090196078431372548" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
@@ -127,8 +131,8 @@
         <namedColor name="EBF0F7">
             <color red="0.92156862745098034" green="0.94117647058823528" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        <systemColor name="labelColor">
+            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Recipe/Recipe/Views/Cart/Cell/RecipeCardViewCell.xib
+++ b/Recipe/Recipe/Views/Cart/Cell/RecipeCardViewCell.xib
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="RecipeCardViewCell" rowHeight="239" id="KGk-i7-Jjw" customClass="RecipeCardViewCell" customModule="Recipe" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="208" height="239"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" alpha="0.59999999999999998" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="208" height="239"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="a08-KE-mwl">
+                        <rect key="frame" x="0.0" y="0.0" width="208" height="100"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="100" id="Red-GS-cbW"/>
+                        </constraints>
+                    </imageView>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="9hW-7I-c7v">
+                        <rect key="frame" x="5" y="110" width="198" height="89"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="top" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iKi-OH-VrL">
+                                <rect key="frame" x="0.0" y="0.0" width="198" height="20.333333333333332"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zw3-6q-RJN">
+                                <rect key="frame" x="0.0" y="30.333333333333339" width="198" height="58.666666666666657"/>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
+                                <color key="tintColor" name="A1A1A1"/>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal" title="View Recipe &gt;"/>
+                            </button>
+                        </subviews>
+                    </stackView>
+                    <view alpha="0.80000000000000004" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gME-rP-UpW">
+                        <rect key="frame" x="5" y="5" width="60" height="20"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="kcL-U6-xpR">
+                                <rect key="frame" x="3" y="1" width="53.333333333333336" height="18"/>
+                                <subviews>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="person" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="lE0-lJ-Jp2" userLabel="personImg">
+                                        <rect key="frame" x="0.0" y="1.6666666666666652" width="18" height="15.333333333333336"/>
+                                        <color key="tintColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="18" id="8oL-kO-fVW"/>
+                                            <constraint firstAttribute="height" constant="18" id="PaK-5p-V6Q"/>
+                                        </constraints>
+                                    </imageView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="10" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gg9-qr-b01" userLabel="Persons">
+                                        <rect key="frame" x="20" y="0.0" width="11.333333333333336" height="18"/>
+                                        <color key="tintColor" name="EBF0F7"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="10"/>
+                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dw7-aG-TLG" userLabel="selectAmount">
+                                        <rect key="frame" x="33.333333333333336" y="0.0" width="20" height="18"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="20" id="9tg-3X-ash"/>
+                                        </constraints>
+                                        <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                        <state key="normal" title="⌵"/>
+                                    </button>
+                                </subviews>
+                            </stackView>
+                        </subviews>
+                        <color key="backgroundColor" name="171717"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="20" id="tYI-Bi-s3G"/>
+                            <constraint firstAttribute="width" constant="60" id="xSi-2C-nTY"/>
+                        </constraints>
+                    </view>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ezm-Y1-Ivn">
+                        <rect key="frame" x="170" y="5" width="30" height="20"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="20" id="9hL-Bc-TFP"/>
+                        </constraints>
+                        <color key="tintColor" name="EBF0F7"/>
+                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                        <state key="normal" title="⌦"/>
+                    </button>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="trailing" secondItem="Ezm-Y1-Ivn" secondAttribute="trailing" constant="8" id="3US-ev-uPr"/>
+                    <constraint firstItem="9hW-7I-c7v" firstAttribute="top" secondItem="a08-KE-mwl" secondAttribute="bottom" constant="10" id="3vL-Kf-awo"/>
+                    <constraint firstAttribute="trailing" secondItem="9hW-7I-c7v" secondAttribute="trailing" constant="5" id="N9d-2k-fbg"/>
+                    <constraint firstItem="9hW-7I-c7v" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="5" id="NRt-pe-be0"/>
+                    <constraint firstItem="a08-KE-mwl" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="Nuw-me-sM6"/>
+                    <constraint firstItem="Ezm-Y1-Ivn" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="5" id="PFO-JK-hL6"/>
+                    <constraint firstAttribute="bottom" secondItem="9hW-7I-c7v" secondAttribute="bottom" constant="40" id="WZe-fx-pgK"/>
+                    <constraint firstItem="gME-rP-UpW" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="5" id="b7h-by-43O"/>
+                    <constraint firstAttribute="trailing" secondItem="a08-KE-mwl" secondAttribute="trailing" id="iAe-nl-kxN"/>
+                    <constraint firstItem="gME-rP-UpW" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="5" id="nqk-XX-vLf"/>
+                    <constraint firstItem="a08-KE-mwl" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="pZv-D6-LQS"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="cardImageView" destination="a08-KE-mwl" id="ecG-4w-s4V"/>
+                <outlet property="closeButton" destination="Ezm-Y1-Ivn" id="Uh9-Qk-a7a"/>
+                <outlet property="selectDropdownMenuButton" destination="dw7-aG-TLG" id="Q4q-h9-Kv6"/>
+                <outlet property="selectPeopleLabel" destination="gg9-qr-b01" id="C7Y-yq-5Tx"/>
+                <outlet property="titleLabel" destination="iKi-OH-VrL" id="O1p-to-N1h"/>
+            </connections>
+            <point key="canvasLocation" x="-45.801526717557252" y="16.549295774647888"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <image name="person" catalog="system" width="128" height="121"/>
+        <namedColor name="171717">
+            <color red="0.090196078431372548" green="0.090196078431372548" blue="0.090196078431372548" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="A1A1A1">
+            <color red="0.63137254901960782" green="0.63137254901960782" blue="0.63137254901960782" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="EBF0F7">
+            <color red="0.92156862745098034" green="0.94117647058823528" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Recipe/Recipe/Views/Cart/Cell/RecipeCardViewCell.xib
+++ b/Recipe/Recipe/Views/Cart/Cell/RecipeCardViewCell.xib
@@ -117,7 +117,7 @@
         </tableViewCell>
     </objects>
     <resources>
-        <image name="person" catalog="system" width="128" height="121"/>
+        <image name="person" catalog="system" width="32" height="32"/>
         <namedColor name="171717">
             <color red="0.090196078431372548" green="0.090196078431372548" blue="0.090196078431372548" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/Recipe/Recipe/Views/Cart/Cell/RecipeCardViewCell.xib
+++ b/Recipe/Recipe/Views/Cart/Cell/RecipeCardViewCell.xib
@@ -94,6 +94,7 @@
                         </state>
                     </button>
                 </subviews>
+                <color key="backgroundColor" name="navigation-color"/>
                 <constraints>
                     <constraint firstAttribute="trailing" secondItem="Ezm-Y1-Ivn" secondAttribute="trailing" constant="8" id="3US-ev-uPr"/>
                     <constraint firstItem="9hW-7I-c7v" firstAttribute="top" secondItem="a08-KE-mwl" secondAttribute="bottom" constant="10" id="3vL-Kf-awo"/>
@@ -130,6 +131,9 @@
         </namedColor>
         <namedColor name="EBF0F7">
             <color red="0.92156862745098034" green="0.94117647058823528" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="navigation-color">
+            <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <systemColor name="labelColor">
             <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>


### PR DESCRIPTION
Completed recipes cart screen.
![Simulator Screen Shot - iPhone 14 Pro - 2024-10-09 at 20 12 17](https://github.com/user-attachments/assets/acaad522-9afc-49eb-9331-d118135f09ca)
![Simulator Screen Shot - iPhone 14 Pro - 2024-10-09 at 20 12 29](https://github.com/user-attachments/assets/0f11ec3b-bf9d-4b28-b555-6bfdb76b9e65)
![Simulator Screen Shot - iPhone 14 Pro - 2024-10-09 at 20 12 39](https://github.com/user-attachments/assets/4fd5698b-6dc1-4c65-b320-202ae96f0be0) 

### Implementation
- Added an undo / redo stack to keep track of user actions when ingredients are moved between sections.
- Updated RealmDB models to store the undo state, ensuring that data persists when users exit the screen.
- Improved the UI binding in the `CartVC` to display the 'No Data' view when Data is empty or null.
- Adjusting serving size, marking ingredients as done, deleting individual recipes, clearing the entire list, and sharing recipe to social media

